### PR TITLE
change top navigation to match the sidebar

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,7 @@
     </div>
     <div class="row footer-child">
       <div class="container">
-        <h3>Get in touch with us</h3>
+        <h3>Stay up to date</h3>
         <ul class="list list--none list--hor">
           <li><a href="/blog.xml"><i class="fa fa-rss"></i> Read our feed</a></li>
           <li><a href="https://twitter.com/RailsGirlsSoC" target="_blank"><i class="fa fa-twitter"></i> Follow us on Twitter</a></li>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -3,13 +3,15 @@
     <ul class="col-sm-3">
       <li>RGSoC</li>
       <li><a href="/about/">About</a></li>
-      <li><a href="/about/code-of-conduct">CoC</a></li>
       <li><a href="/about/team">Team</a></li>
+      <li><a href="/about/roles">Roles</a></li>
+      <li><a href="/about/code-of-conduct">CoC</a></li>
+      
     </ul>
     <ul class="col-sm-3">
       <li>Get involved</li>
-      <li><a href="/guide/coaching-company">Coaching Company</a></li>
       <li><a href="/guide/coaching">Coaches</a></li>
+      <li><a href="/guide/coaching-company">Coaching Company</a></li>
       <li><a href="/guide/projects">Project Mentor</a></li>
       <li><a href="/guide/supervisors">Supervisor</a></li>
     </ul>


### PR DESCRIPTION
as per @katrin-k's note/request, some bits in the navigation have been changed to reflect the order in the sidebar. Maybe we could also switch "Students" and "Get Involved"?