### PR TITLE
Add a title attribute on name links (campaign - donations)

### DIFF
--- a/assets/javascripts/donations.js
+++ b/assets/javascripts/donations.js
@@ -168,9 +168,9 @@ $.extend(Donation.prototype, {
   name: function() {
     var name = this.data.name || this.data.twitter_handle || this.data.github_handle || 'Anonymous';
     if (this.data.homepage) {
-      return $('<a></a>').attr('href', this.data.homepage).text(name);
+      return $('<a></a>').attr('href', this.data.homepage).attr('title', name).text(name);
     } else {
-      return $('<span></span>').text(name);
+      return $('<span></span>').attr('title', name).text(name);
     }
   },
   github: function() {


### PR DESCRIPTION
Donations with long names (e.g. "Turing School of Software & Design") have their names truncated. This adds a "title" attribute on the link so you see the full name when hovering over it.

I edited this right on Github so haven't tested it. Please review carefully.