### PR TITLE
hide the sidebar on small screens

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -7,7 +7,7 @@ sponsors: yes
   <article class="col-md-8">
     {{ content }}
   </article>
-  <aside class="col-md-3 col-md-offset-1">
+  <aside class="col-md-3 col-md-offset-1 hidden-sm">
     {% if page.sidebar == "content" %}
       {% include content_sidebar.html %}
     {% endif %}

--- a/blog/index.html
+++ b/blog/index.html
@@ -35,7 +35,7 @@ current: blog
       {% endif %}
     </div>
   </div>
-  <div class="col-md-3 col-md-offset-1">
+  <div class="col-md-3 col-md-offset-1 hidden-sm">
     {% include blog_sidebar.html %}
   </div>
 </section>


### PR DESCRIPTION
This is a meta task from issue #65 

"The donate button is way bigger than necessary in the page views. This is from the application guide, it comes from the sidebar and could probably also be hidden.
Not sure if we need all the sidebar links at the bottom of each page; in theory we can access everything through the top menu."

As per Laura's advice I hid the side bar on 'sm' screens in the 'bootstrap' layout, and on 'xs' screens in the 'page' layout. It seems to work well, and there are no averse affects as far as I can see. 

There are still some improvements we could make to how the sidebar looks from 'md' size upwards, as the button is a little cut off. Baby steps :)

