### PR TITLE
fixed weird h1 showing in nav

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -34,7 +34,7 @@
 <div class="container">
   <div class="row">
     <div class="col-xs-7">
-      <h1 class="logo-small"><a href="/" title="">Rails Girls Summer of Code</a></h1>
+      <h1 class="logo-small"><a href="/" title="Rails Girls Summer of Code"></a></h1>
     </div>
     <div class="col-xs-5">
       <nav class="header-nav text-right">


### PR DESCRIPTION
@lislis and @alicetragedy this fixes that weird thing when you hit cmd + f and try to search through the text on the page, and the 'Rails Girls Summer of Code' text was appearing highlighted in the header.

To solve it I simply removed the h1 text, as that is the part that was highlighting. Is this ok practice?

![screen shot 2015-04-25 at 6 48 20 pm](https://cloud.githubusercontent.com/assets/1307818/7333910/4339d75e-eb80-11e4-8862-5f5936946d1c.png)

This will fix it on the Summer of Code website, but not the teams app. I'll do that one in a few, if this fix is ok, and actually not terrible practice
