### PR TITLE
Fix RSS feed

### DIFF
--- a/blog.xml
+++ b/blog.xml
@@ -16,7 +16,7 @@ layout: null
 
   {% for post in site.posts %}
   <entry>
-    <title>{{ post.title }}</title>
+    <title>{{ post.title | xml_escape }}</title>
     <author>
       <name>{{ post.author }}</name>
       {% if post.twitter %}


### PR DESCRIPTION
This fixes XML error on /blog.xml due to unescaped post titles, although this fixes the RSS feed, I'm not sure if other elements should be escaped as well.

Here's the [validation output from w3.org](https://validator.w3.org/feed/check.cgi?url=http%3A%2F%2Frailsgirlssummerofcode.org%2Fblog.xml) before the fix.

**Production:**
![before](http://note.io/1HrZfm1)

**Development:**
![before](http://note.io/1IV7QmT)

**After fix**
![after](http://note.io/1Fb6oqm)