### PR TITLE
Render bulleted list

### DIFF
--- a/blog/_posts/2015-07-19-Meet-Team-RailsGEnthusiasts.md
+++ b/blog/_posts/2015-07-19-Meet-Team-RailsGEnthusiasts.md
@@ -40,6 +40,7 @@ Well, the name of our team speaks for itself about our big enthusiasm for learni
 
 Our project is RubyGameDev.com with owner and our mentor Andrew Havens. It's a community-driven, information hub designed to help people build games in Ruby. 
 Some of our tasks are:
+
 - Create guides/tutorials section
 - Improvements on current features
 - Creating new features


### PR DESCRIPTION
It seems to me like the published blog post doesn't have bullets in that one list. I think the reason is the lack of a blank line before the list -- it works on github without it, but I'm assuming it's a non-standard github-flavored markdown extension.
