### PR TITLE
Escape the author name in the feed

### DIFF
--- a/blog.xml
+++ b/blog.xml
@@ -18,7 +18,7 @@ layout: null
   <entry>
     <title>{{ post.title | xml_escape }}</title>
     <author>
-      <name>{{ post.author }}</name>
+      <name>{{ post.author | xml_escape }}</name>
       {% if post.twitter %}
       <uri>http://twitter.com/{{ post.twitter }}</uri>
       {% endif %}


### PR DESCRIPTION
The feed is broken, because of & in the author name.
