### PR TITLE
add new student guide

### DIFF
--- a/_includes/content_sidebar.html
+++ b/_includes/content_sidebar.html
@@ -13,6 +13,7 @@
     <h4>Students</h4>
     <ul class="list list--none list--archive">
       <li><a href="/students/application"   {% if page.url == '/students/application/'  %}class="current"{% endif %}>Application Guide</a></li>
+      <li><a href="/students/finding-your-team"   {% if page.url == '/students/finding-your-team/'  %}class="current"{% endif %}>Finding your team</a></li>
       <li><a href="/students/todo"          {% if page.url == '/students/todo/'         %}class="current"{% endif %}>What to expect</a></li>
       <li><a href="/students/conferences"   {% if page.url == '/students/conferences/'  %}class="current"{% endif %}>Conferences</a></li>
       <!--

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -19,6 +19,7 @@
     <ul class="col-sm-3">
       <li>Students</li>
       <li><a href="/students/application">Application Guide</a></li>
+      <li><a href="/students/finding-your-team">Finding your team</a></li>
       <li><a href="/students/todo">What to expect</a></li>
       <li><a href="/students/conferences">Conferences</a></li>
     </ul>

--- a/students/application.md
+++ b/students/application.md
@@ -81,8 +81,6 @@ As a team, you will be required to define your goals for the program, and plan t
 <h4 id="project">A project</h4>
 
 A good place to start is to have a look <a href="https://teams.railsgirlssummerofcode.org/projects">here</a> at our list of projects approved for RGSoC 2016. We have a wonderful variety of interesting Open Source projects, so we understand that it can be tricky to know how to proceed! Be sure to already ask your prospective coaches for their input on which project they feel would be suitable, or other people of your local community - in particular, people who are familiar with your experience so far.  
-<!-- ADD LINK -->
-The teams (and their projects) from last year are here. 
 
 <h3 id="place-application">Placing your application</h3>
 

--- a/students/application.md
+++ b/students/application.md
@@ -12,7 +12,7 @@ permalink: /students/application/
 
 <p>This guide gives you all the information about what you will need when applying for Summer of Code. Please read this carefully to ensure you know about all the requirements of a good and complete application.</p>
 
-**Applications for Rails Girls Summer of Code 2016 will open end of February and will close on March 15th, at 18:00 CET**.
+**Applications for Rails Girls Summer of Code 2016 will open end of February (exact date will follow) and will close on March 15th, at 18:00 CET**.
 
 <ul>
   <li><a href="#eligibility">Who is eligible to apply?</a></li>
@@ -64,21 +64,19 @@ For further information on finding a teammate we have prepared a detailed guide 
 Coaches are developers who sit down with you, guide you through relevant coding steps and troubleshoot with you at regular intervals. Consequently, it is **required** that they are based in the same city as your team.  
 From past experiences, we recommend a time of 4-8 hours per week of coaching time. Therefore, we require a minimum of 2 coaches, so they can share the time commitment, and you and your teammate will have more flexible support.  
 
-For further information on what is required of a coach, and how to find one, we have prepared a detailed guide <a href="/students/finding-your-team">here</a>. 
+Our <a href="/guide/coaching/">guide for coaches</a> will help to give you insight on what is required of them, and help you to explain this to prospective coaches. For further information on how to find coaches, we have also prepared a detailed guide <a href="/students/finding-your-team">here</a>. 
 
 
 <h4 id="workplace">A place to work</h4>
 
-Working at a desk next to your team pair and to your coaches is a great scenario; having access to a team of coaches who can share the load is ideal. You will need an environment beneficial to dedicating yourself to your project for 3 months.
+Working at a desk next to your team pair and to your coaches is a great scenario and having access to a team of coaches who can share the load is ideal. You will need an environment beneficial to dedicating yourself to your project for 3 months.
 This could be your home, a co-working space, your current work office or a <a href="/guide/coaching-company/">Coaching Company</a>. As long as you are safe and productive, you can choose where you will work.
 
 
 <h4 id="self-mgmt">The ability to self-manage and motivate</h4>
 
-This is a very important point for us, as the program is **self-guided**. This means that there will not be someone beside you telling you what to do next at all times. While you will have time with your coaches each week, you will not have them by your side for the entire duration of the project.  
-As a team, you will be required to define your goals for the program, and plan together how you will meet these goals. We are always here to help you with this planning, but it is up to you to stick to your plan and achieve your goals.  
-
-Our <a href="/guide/coaching/">guide for coaches</a> will also help to give you insight on what is required, and help you to explain this to prospective coaches.
+This is a very important point for us, as the program is **self-guided**. This means that there will not be someone beside you telling you what to do at all times. While you will have time with your coaches each week, you won't have them by your side for the entire duration of the project.  
+As a team, you will be required to define your goals for the program, and plan together how you will meet these goals. We are always here to help you with this planning, but it's up to you to stick to your plan and achieve your goals.  
 
 <h4 id="project">A project</h4>
 
@@ -92,12 +90,12 @@ The teams (and their projects) from last year are here.
 
 In order to submit your application, you are **required** to have a teammate and, at a minimum, two coaches. At the bottom of this guide you will find a checklist to make sure that you have everything you need for a complete application.
 
-The application form is split into three sections. In the first section, you will be asked to answer lots of questions about yourself, your experience with coding so far, and other information that is relevant to our decision making process. We want to get to know you! You and your teammate will fill in this information separately.  
-The other sections are related to your project and team setup and they should be filled out as a team. For the project section, you will select your project via a dropdown menu. You will also have the opportunity to select a secondary project, which is there in case you do not get your first choice. The majority of our applicants are approved to work on their first choice, so this is just a back-up.  
+The application form is split into three sections. In the first section, you will be asked to answer lots of questions about yourself, your experience with coding so far, and other information that is relevant to our decision-making process. We want to get to know you! You and your teammate will fill in this information separately.  
+The other sections are related to your project and team setup and they should be filled out as a team. For the project section, you will select your project via a dropdown menu. You will also have the opportunity to select a secondary project, which is there as a back-up, in case you don't get your first choice.
 
 It is possible to save drafts of your application. This means that you can partially fill it in, and save your progress for later. 
 
-If you have any queries about this, please contact us.
+If you have any queries about the application process, please contact us.
 
 <h3 id="selection">Selection and judging</h3>
 
@@ -119,7 +117,7 @@ During the Summer of Code we have the following requirements which students have
 * Provide an email address and Twitter account for social and promotional events.
 * Participate in non-coding related community events (e.g. the all-team chat, RGSoC social events).
 * Agree to have published team information on our website and blog (e.g. team introduction, team blog posts). This includes some form of visual material of yourself.
-* In case of participation in a conference where tickets are provided by RGSoC: Hold a lightning talk about your project work or write a blog post about the conference participation.
+* In case of participation in a conference where tickets are provided by RGSoC: Hold a lightning talk about your project work or write a blog post about the conference.
 
 Rails Girls Summer of Code will assist and support you with any of these requirements. As a further insight on this, or on setting up a good working environment, please read our article on <a href="/students/todo/">“What to expect”</a>, where we gathered suggestions and recommendations for students.
 We strongly advise you to get acquainted with these requirements before and during application time. We will make sure they are complied with and will take steps in case of breaches.  
@@ -127,8 +125,8 @@ If you have any questions about the above list, please <a href="mailto:summer-of
 
 <h3 id="volunteer-teams">A note on volunteer teams</h3>
 
-As well as the funded teams, every year the Rails Girls Summer of Code has also had a few selected volunteer teams. Volunteer teams are teams that participate in the program without the monthly stipend. 
-Volunteer teams adhere to the same guidelines as funded teams, and apart from the stipend they receive the same amount of support as the other teams, and are involved in the social activities. 
+As well as the funded teams, every year Rails Girls Summer of Code has also had a few selected volunteer teams. Volunteer teams are teams that participate in the program without the monthly stipend. 
+Volunteer teams adhere to the same guidelines as funded teams and apart from the stipend, they receive the same amount of support as the other teams and are just as involved in the social activities. 
 Due to this, volunteer teams are also subjected to the selection process. In your application, you will have the option to select whether you are applying as a funded team, a volunteer team, or you can select both options. 
 
 <h3 id="volunteer-teams">Before you apply: the checklist</h3>

--- a/students/application.md
+++ b/students/application.md
@@ -55,22 +55,22 @@ The scholarship will be based on where you live, how much your set expenses are,
 <h4 id="pair">Another Student to Pair With</h4>
 
 Finding a teammate before submitting your application is required. It is important that you both work well together as you will be working very closely throughout the summer, planning your team goals together, and being the closest support for one another!  
-<!-- ADD LINK -->
-For further information on finding a teammate, including tips from past students, we have prepared a detailed guide for you here. 
+
+For further information on finding a teammate we have prepared a detailed guide for you <a href="/students/find-your-team">here</a>. 
 
 
 <h4 id="coaches">Coaches</h4>
 
 Coaches are developers who sit down with you, guide you through relevant coding steps and troubleshoot with you at regular intervals. Consequently, it is **required** that they are based in the same city as your team.  
 From past experiences, we recommend a time of 4-8 hours per week of coaching time. Therefore, we require a minimum of 2 coaches, so they can share the time commitment, and you and your teammate will have more flexible support.  
-<!-- ADD LINK -->
-For further information on what is required of a coach, and how to find one, we have prepared a detailed guide here. 
+
+For further information on what is required of a coach, and how to find one, we have prepared a detailed guide <a href="/students/find-your-team">here</a>. 
 
 
 <h4 id="workplace">A Place to Work</h4>
 
 Working at a desk next to your team pair and to your coaches is a great scenario; having access to a team of coaches who can share the load is ideal. You will need an environment beneficial to dedicating yourself to your project for 3 months.
-This could be your home, a co-working space, your current work office or a Coaching Company. As long as you are safe and productive, you can choose where you will work.
+This could be your home, a co-working space, your current work office or a <a href="/guide/coaching-company/">Coaching Company</a>. As long as you are safe and productive, you can choose where you will work.
 
 
 <h4 id="self-mgmt">The Ability to Self-Manage and Motivate</h4>
@@ -78,7 +78,7 @@ This could be your home, a co-working space, your current work office or a Coach
 This is a very important point for us, as the program is **self-guided**. This means that there will not be someone beside you telling you what to do next at all times. While you will have time with your coaches each week, you will not have them by your side for the entire duration of the project.  
 As a team, you will be required to define your goals for the program, and plan together how you will meet these goals. We are always here to help you with this planning, but it is up to you to stick to your plan and achieve your goals.  
 
-Our <a href="http://railsgirlssummerofcode.org/guide/coaching/">guide for coaches</a> will also help to give you insight on what is required, and help you to explain this to prospective coaches.
+Our <a href="/guide/coaching/">guide for coaches</a> will also help to give you insight on what is required, and help you to explain this to prospective coaches.
 
 <h4 id="project">A Project</h4>
 
@@ -108,7 +108,7 @@ Applications sent after the deadline cannot be considered for judging.
 
 <h3 id="requirements-program">Requirements during the program</h3>
 
-Along with this application guide, please also read about <a href="http://railsgirlssummerofcode.org/students/todo/">what will be asked of you</a> over the summer, besides diving into code. Rails Girls Summer of Code focuses on students learning to code, but is also a community event.  
+Along with this application guide, please also read about <a href="/students/todo/">what will be asked of you</a> over the summer, besides diving into code. Rails Girls Summer of Code focuses on students learning to code, but is also a community event.  
 
 During the Summer of Code we have the following requirements which students have to agree with and, in case of being selected, will sign for in a written agreement:
 
@@ -121,7 +121,7 @@ During the Summer of Code we have the following requirements which students have
 * Agree to have published team information on our website and blog (e.g. team introduction, team blog posts). This includes some form of visual material of yourself.
 * In case of participation in a conference where tickets are provided by RGSoC: Hold a lightning talk about your project work or write a blog post about the conference participation.
 
-Rails Girls Summer of Code will assist and support you with any of these requirements. As a further insight on this, or on setting up a good working environment, please read our article on <a href="http://railsgirlssummerofcode.org/students/todo/">“What to expect”</a>, where we gathered suggestions and recommendations for students.
+Rails Girls Summer of Code will assist and support you with any of these requirements. As a further insight on this, or on setting up a good working environment, please read our article on <a href="/students/todo/">“What to expect”</a>, where we gathered suggestions and recommendations for students.
 We strongly advise you to get acquainted with these requirements before and during application time. We will make sure they are complied with and will take steps in case of breaches.  
 If you have any questions about the above list, please <a href="mailto:summer-of-code@railsgirls.com">contact us</a>.
 

--- a/students/application.md
+++ b/students/application.md
@@ -95,7 +95,7 @@ The other sections are related to your project and team setup and they should be
 
 It is possible to save drafts of your application. This means that you can partially fill it in, and save your progress for later. 
 
-If you have any queries about the application process, please contact us.
+If you have any queries about the application process, please <a href="mailto:summer-of-code@railsgirls.com">contact us</a>.
 
 <h3 id="selection">Selection and judging</h3>
 

--- a/students/application.md
+++ b/students/application.md
@@ -10,23 +10,97 @@ permalink: /students/application/
 
 <h1>Application Guide</h1>
 
-Applications for Rails Girls Summer of Code will be open for 1 month <strong>starting mid February 2016</strong>.
-We're currently revamping the guide for 2016 and will update it soon. Stay tuned!
+<p>This guide gives you all the information about what you will need when applying for Summer of Code. Please read this carefully to ensure you know about all the requirements of a good and complete application.</p>
 
-In the meanwhile, you can take a look at the eligibility criteria below.  
+<ul>
+  <li><a href="#eligibility">Who is eligible to apply?</a></li>
+  <li><a href="#stipend">How much is the scholarship?</a></li>
+  <li><a href="#components">What do you need to apply?</a></li>
+    <ul>
+      <li><a href="#pair">Another Student to Pair With</a></li>
+      <li><a href="#coaches">Coaches</a></li>
+      <li><a href="#workplace">A Place to Work</a></li>
+      <li><a href="#self-mgmt">The Ability to Self-Manage and Motivate</a></li>
+      <li><a href="#project">A Project</a></li>
+    </ul>
+  
+  <li><a href="#place-application">Placing Your Application</a></li>
+  <li><a href="#selection">Selection and Judging</a></li>
+  <li><a href="#requirements-program">Requirements During the Program</a></li>
+  <li><a href="#volunteer-teams">A Note on Volunteer Teams</a></li>
+  <li><a href="#checklist">Before You Apply: The Checklist</a></li>
+</ul>
 
-<h4 id="eligibility">Who Is Eligible to Apply?</h4>
 
-Applications to Rails Girls Summer of Code are open to anyone who:
+<h3 id="eligibility">Who is eligible to apply?</h3>
 
-* Self-identifies as female and/or has experiences being socialized as female.
-  No-one is excluded from applying on the basis of gender, but people who
-  self-identify as female, or have experiences being socialized as female, are
-  given preference during selection.
-* Has attended one or more workshops organized by and is involved in communities like **<a href="http://railsgirls.com/">Rails Girls</a>**, Railsbridge, Black Girls Code, PyLadies, or similar initiatives.
-* Has about a year (or more) experience of continuous learning, i.e. has significantly expanded their programming skills in a study group, or independently, by working on a suitable project. We will ask for coding examples.
-* Can spend 3 months (July to September 2016) working **fulltime** on their Open Source project of
-  choice.
+All people with non-binary gender identities or who identify as women are welcome to apply; while no one is excluded from applying on the basis of gender, female and genderfluid applicants will be given preference during selection. Further to this, we look for applicants;
+
+* who are involved with, or have attended one or more workshops organized by communities like <a href="http://railsgirls.com/">Rails Girls</a>, Railsbridge, Black Girls Code, PyLadies, or similar initiatives.
+  
+* with at least a year’s experience of continuous learning, i.e. has significantly expanded their programming skills in a study group, or independently, by working on a suitable project. We will ask for coding examples.
+
+* who can spend 3 months (July to September 2016) working **full-time** on their Open Source project of choice.
 
 You do **not** have to be a student at a University to apply, and there are certainly no degree or age limitations.  
-In order to apply, you will need a team mate (based in your same city for the duration of the program) and at least two coaches who are available during the day to follow your progress and help you and your team mate when you get stuck.
+
+<h3 id="stipend">How much is the scholarship?</h3>
+
+The scholarship will be based on where you live, how much your set expenses are, and any special circumstances which you might wish to share with us so that we can consider them.
+
+<h3 id="components">What do you need to apply?</h3>
+
+<h4 id="pair">Another Student to Pair With</h4>
+
+Finding a teammate before submitting your application is required. It is important that you both work well together as you will be working very closely throughout the summer, planning your team goals together, and being the closest support for one another!  
+<!-- ADD LINK -->
+For further information on finding a teammate, including tips from past students, we have prepared a detailed guide for you here. 
+
+
+<h4 id="coaches">Coaches</h4>
+
+Coaches are developers who sit down with you, guide you through relevant coding steps and troubleshoot with you at regular intervals. Consequently, it is **required** that they are based in the same city as your team.  
+From past experiences, we recommend a time of 4-8 hours per week of coaching time. Therefore, we require a minimum of 2 coaches, so they can share the time commitment, and you and your teammate will have more flexible support.  
+<!-- ADD LINK -->
+For further information on what is required of a coach, and how to find one, we have prepared a detailed guide here. 
+
+
+<h4 id="workplace">A Place to Work</h4>
+
+Working at a desk next to your team pair and to your coaches is a great scenario; having access to a team of coaches who can share the load is ideal. You will need an environment beneficial to dedicating yourself to your project for 3 months.
+This could be your home, a co-working space, your current work office or a Coaching Company. As long as you are safe and productive, you can choose where you will work.
+
+
+<h4 id="self-mgmt">The Ability to Self-Manage and Motivate</h4>
+
+This is a very important point for us, as the program is **self-guided**. This means that there will not be someone beside you telling you what to do next at all times. While you will have time with your coaches each week, you will not have them by your side for the entire duration of the project.  
+As a team, you will be required to define your goals for the program, and plan together how you will meet these goals. We are always here to help you with this planning, but it is up to you to stick to your plan and achieve your goals.  
+
+Our <a href="http://railsgirlssummerofcode.org/guide/coaching/">guide for coaches</a> will also help to give you insight on what is required, and help you to explain this to prospective coaches.
+
+<h4 id="project">A Project</h4>
+
+A good place to start is to have a look <a href="https://teams.railsgirlssummerofcode.org/projects">here</a> at our list of projects approved for RGSoC 2016. We have a wonderful variety of interesting Open Source projects, so we understand that it can be tricky to know how to proceed! Be sure to already ask your prospective coaches for their input on which project they feel would be suitable, or other people of your local community - in particular, people who are familiar with your experience so far.  
+<!-- ADD LINK -->
+The teams (and their projects) from last year are here. 
+
+<h3 id="place-application">Placing your application</h3>
+
+Applications for Rails Girls Summer of Code will be open on February 22nd and will close **on March 15th, at 18:00 CET**.
+
+In order to submit your application, you are **required** to have a teammate and, at a minimum, two coaches. At the bottom of this guide you will find a checklist to make sure that you have everything you need for a complete application.
+
+The application form is split into three sections. In the first section, you will be asked to answer lots of questions about yourself, your experience with coding so far, and other information that is relevant to our decision making process. We want to get to know you! You and your teammate will fill in this information separately.  
+The other sections are related to your project and team setup and they should be filled out as a team. For the project section, you will select your project via a dropdown menu. You will also have the opportunity to select a secondary project, which is there in case you do not get your first choice. The majority of our applicants are approved to work on their first choice, so this is just a back-up.  
+
+It is possible to save drafts of your application. This means that you can partially fill it in, and save your progress for later. 
+
+If you have any queries about this, please contact us.
+
+
+
+
+
+
+
+

--- a/students/application.md
+++ b/students/application.md
@@ -12,7 +12,7 @@ permalink: /students/application/
 
 <p>This guide gives you all the information about what you will need when applying for Summer of Code. Please read this carefully to ensure you know about all the requirements of a good and complete application.</p>
 
-**Applications for Rails Girls Summer of Code will be open starting February 22nd and will close on March 15th, at 18:00 CET**.
+**Applications for Rails Girls Summer of Code 2016 will open end of February and will close on March 15th, at 18:00 CET**.
 
 <ul>
   <li><a href="#eligibility">Who is eligible to apply?</a></li>
@@ -88,7 +88,7 @@ The teams (and their projects) from last year are here.
 
 <h3 id="place-application">Placing your application</h3>
 
-**Applications for Rails Girls Summer of Code will be open starting February 22nd and will close on March 15th, at 18:00 CET**.
+**Applications for Rails Girls Summer of Code 2016 will open end of February and will close on March 15th, at 18:00 CET**.
 
 In order to submit your application, you are **required** to have a teammate and, at a minimum, two coaches. At the bottom of this guide you will find a checklist to make sure that you have everything you need for a complete application.
 

--- a/students/application.md
+++ b/students/application.md
@@ -135,11 +135,12 @@ Due to this, volunteer teams are also subjected to the selection process. In you
 
 Here is the basic checklist for your application:
 
-* Have you read, and fully understood, this guide?
-* Have you found a teammate? 
-* Has your team selected a project? 
-* Has your team found at least two coaches who will commit to helping you?
-* Has your team found a suitable workspace for the duration of the program? 
-* Do you agree with and meet all of the requirements listed above?
+<span class="glyphicon glyphicon-unchecked"></span> Have you read, and fully understood, this guide?  
+<span class="glyphicon glyphicon-unchecked"></span> Have you found a teammate?  
+<span class="glyphicon glyphicon-unchecked"></span> Has your team selected a project?  
+<span class="glyphicon glyphicon-unchecked"></span> Has your team found at least two coaches who will commit to helping you?  
+<span class="glyphicon glyphicon-unchecked"></span> Has your team found a suitable workspace for the duration of the program?  
+<span class="glyphicon glyphicon-unchecked"></span> Do you agree with and meet all of the requirements listed above?  
+
 
 

--- a/students/application.md
+++ b/students/application.md
@@ -12,6 +12,8 @@ permalink: /students/application/
 
 <p>This guide gives you all the information about what you will need when applying for Summer of Code. Please read this carefully to ensure you know about all the requirements of a good and complete application.</p>
 
+**Applications for Rails Girls Summer of Code will be open starting February 22nd and will close on March 15th, at 18:00 CET**.
+
 <ul>
   <li><a href="#eligibility">Who is eligible to apply?</a></li>
   <li><a href="#stipend">How much is the scholarship?</a></li>
@@ -86,7 +88,7 @@ The teams (and their projects) from last year are here.
 
 <h3 id="place-application">Placing your application</h3>
 
-Applications for Rails Girls Summer of Code will be open on February 22nd and will close **on March 15th, at 18:00 CET**.
+**Applications for Rails Girls Summer of Code will be open starting February 22nd and will close on March 15th, at 18:00 CET**.
 
 In order to submit your application, you are **required** to have a teammate and, at a minimum, two coaches. At the bottom of this guide you will find a checklist to make sure that you have everything you need for a complete application.
 
@@ -97,10 +99,47 @@ It is possible to save drafts of your application. This means that you can parti
 
 If you have any queries about this, please contact us.
 
+<h3 id="selection">Selection and Judging</h3>
 
+Applications are reviewed on a case-by-case basis by a group of real human beings in the coding community; we aim for a diverse group of teams consisting of different countries, projects, backgrounds and skill levels.  
+Remember: Successful applications are not “first in, best dressed”, but are judged on how well they fulfill eligibility criteria. Don’t rush your application, but rather take your time to find your teammate, your coaches, and to choose the most suitable project for your team.  
 
+Applications sent after the deadline cannot be considered for judging.
 
+<h3 id="requirements-program">Requirements during the program</h3>
 
+Along with this application guide, please also read about <a href="http://railsgirlssummerofcode.org/students/todo/">what will be asked of you</a> over the summer, besides diving into code. Rails Girls Summer of Code focuses on students learning to code, but is also a community event.  
 
+During the Summer of Code we have the following requirements which students have to agree with and, in case of being selected, will sign for in a written agreement:
+
+* Participate full-time from July 1st to September 30th 2016
+* Continuously work on the chosen and approved Open Source project.
+* Keep track of your work with a short, daily summary.
+* Keep regular contact to your supervisor and your mentor and abide to reaction times for communication.
+* Provide an email address and Twitter account for social and promotional events.
+* Participate in non-coding related community events (e.g. the all-team chat, RGSoC social events).
+* Agree to have published team information on our website and blog (e.g. team introduction, team blog posts). This includes some form of visual material of yourself.
+* In case of participation in a conference where tickets are provided by RGSoC: Hold a lightning talk about your project work or write a blog post about the conference participation.
+
+Rails Girls Summer of Code will assist and support you with any of these requirements. As a further insight on this, or on setting up a good working environment, please read our article on <a href="http://railsgirlssummerofcode.org/students/todo/">“What to expect”</a>, where we gathered suggestions and recommendations for students.
+We strongly advise you to get acquainted with these requirements before and during application time. We will make sure they are complied with and will take steps in case of breaches.  
+If you have any questions about the above list, please <a href="mailto:summer-of-code@railsgirls.com">contact us</a>.
+
+<h3 id="volunteer-teams">A Note on Volunteer Teams</h3>
+
+As well as the funded teams, every year the Rails Girls Summer of Code has also had a few selected volunteer teams. Volunteer teams are teams that participate in the program without the monthly stipend. 
+Volunteer teams adhere to the same guidelines as funded teams, and apart from the stipend they receive the same amount of support as the other teams, and are involved in the social activities. 
+Due to this, volunteer teams are also subjected to the selection process. In your application, you will have the option to select whether you are applying as a funded team, a volunteer team, or you can select both options. 
+
+<h3 id="volunteer-teams">Before You Apply: The Checklist</h3>
+
+Here is the basic checklist for your application:
+
+* Have you read, and fully understood, this guide?
+* Have you found a teammate? 
+* Has your team selected a project? 
+* Has your team found at least two coaches who will commit to helping you?
+* Has your team found a suitable workspace for the duration of the program? 
+* Do you agree with and meet all of the requirements listed above?
 
 

--- a/students/application.md
+++ b/students/application.md
@@ -8,7 +8,7 @@ current-sub: application
 permalink: /students/application/
 ---
 
-<h1>Application Guide</h1>
+<h1>{{page.title}}</h1>
 
 <p>This guide gives you all the information about what you will need when applying for Summer of Code. Please read this carefully to ensure you know about all the requirements of a good and complete application.</p>
 
@@ -56,7 +56,7 @@ The scholarship will be based on where you live, how much your set expenses are,
 
 Finding a teammate before submitting your application is required. It is important that you both work well together as you will be working very closely throughout the summer, planning your team goals together, and being the closest support for one another!  
 
-For further information on finding a teammate we have prepared a detailed guide for you <a href="/students/find-your-team">here</a>. 
+For further information on finding a teammate we have prepared a detailed guide for you <a href="/students/finding-your-team">here</a>. 
 
 
 <h4 id="coaches">Coaches</h4>
@@ -64,7 +64,7 @@ For further information on finding a teammate we have prepared a detailed guide 
 Coaches are developers who sit down with you, guide you through relevant coding steps and troubleshoot with you at regular intervals. Consequently, it is **required** that they are based in the same city as your team.  
 From past experiences, we recommend a time of 4-8 hours per week of coaching time. Therefore, we require a minimum of 2 coaches, so they can share the time commitment, and you and your teammate will have more flexible support.  
 
-For further information on what is required of a coach, and how to find one, we have prepared a detailed guide <a href="/students/find-your-team">here</a>. 
+For further information on what is required of a coach, and how to find one, we have prepared a detailed guide <a href="/students/finding-your-team">here</a>. 
 
 
 <h4 id="workplace">A Place to Work</h4>

--- a/students/application.md
+++ b/students/application.md
@@ -19,18 +19,18 @@ permalink: /students/application/
   <li><a href="#stipend">How much is the scholarship?</a></li>
   <li><a href="#components">What do you need to apply?</a></li>
     <ul>
-      <li><a href="#pair">Another Student to Pair With</a></li>
+      <li><a href="#pair">Another student to pair with</a></li>
       <li><a href="#coaches">Coaches</a></li>
-      <li><a href="#workplace">A Place to Work</a></li>
-      <li><a href="#self-mgmt">The Ability to Self-Manage and Motivate</a></li>
-      <li><a href="#project">A Project</a></li>
+      <li><a href="#workplace">A place to work</a></li>
+      <li><a href="#self-mgmt">The ability to self-manage and motivate</a></li>
+      <li><a href="#project">A project</a></li>
     </ul>
   
-  <li><a href="#place-application">Placing Your Application</a></li>
-  <li><a href="#selection">Selection and Judging</a></li>
-  <li><a href="#requirements-program">Requirements During the Program</a></li>
-  <li><a href="#volunteer-teams">A Note on Volunteer Teams</a></li>
-  <li><a href="#checklist">Before You Apply: The Checklist</a></li>
+  <li><a href="#place-application">Placing your application</a></li>
+  <li><a href="#selection">Selection and judging</a></li>
+  <li><a href="#requirements-program">Requirements during the program</a></li>
+  <li><a href="#volunteer-teams">A note on volunteer teams</a></li>
+  <li><a href="#checklist">Before you apply: the checklist</a></li>
 </ul>
 
 
@@ -52,7 +52,7 @@ The scholarship will be based on where you live, how much your set expenses are,
 
 <h3 id="components">What do you need to apply?</h3>
 
-<h4 id="pair">Another Student to Pair With</h4>
+<h4 id="pair">Another student to pair with</h4>
 
 Finding a teammate before submitting your application is required. It is important that you both work well together as you will be working very closely throughout the summer, planning your team goals together, and being the closest support for one another!  
 
@@ -67,20 +67,20 @@ From past experiences, we recommend a time of 4-8 hours per week of coaching tim
 For further information on what is required of a coach, and how to find one, we have prepared a detailed guide <a href="/students/finding-your-team">here</a>. 
 
 
-<h4 id="workplace">A Place to Work</h4>
+<h4 id="workplace">A place to work</h4>
 
 Working at a desk next to your team pair and to your coaches is a great scenario; having access to a team of coaches who can share the load is ideal. You will need an environment beneficial to dedicating yourself to your project for 3 months.
 This could be your home, a co-working space, your current work office or a <a href="/guide/coaching-company/">Coaching Company</a>. As long as you are safe and productive, you can choose where you will work.
 
 
-<h4 id="self-mgmt">The Ability to Self-Manage and Motivate</h4>
+<h4 id="self-mgmt">The ability to self-manage and motivate</h4>
 
 This is a very important point for us, as the program is **self-guided**. This means that there will not be someone beside you telling you what to do next at all times. While you will have time with your coaches each week, you will not have them by your side for the entire duration of the project.  
 As a team, you will be required to define your goals for the program, and plan together how you will meet these goals. We are always here to help you with this planning, but it is up to you to stick to your plan and achieve your goals.  
 
 Our <a href="/guide/coaching/">guide for coaches</a> will also help to give you insight on what is required, and help you to explain this to prospective coaches.
 
-<h4 id="project">A Project</h4>
+<h4 id="project">A project</h4>
 
 A good place to start is to have a look <a href="https://teams.railsgirlssummerofcode.org/projects">here</a> at our list of projects approved for RGSoC 2016. We have a wonderful variety of interesting Open Source projects, so we understand that it can be tricky to know how to proceed! Be sure to already ask your prospective coaches for their input on which project they feel would be suitable, or other people of your local community - in particular, people who are familiar with your experience so far.  
 <!-- ADD LINK -->
@@ -99,7 +99,7 @@ It is possible to save drafts of your application. This means that you can parti
 
 If you have any queries about this, please contact us.
 
-<h3 id="selection">Selection and Judging</h3>
+<h3 id="selection">Selection and judging</h3>
 
 Applications are reviewed on a case-by-case basis by a group of real human beings in the coding community; we aim for a diverse group of teams consisting of different countries, projects, backgrounds and skill levels.  
 Remember: Successful applications are not “first in, best dressed”, but are judged on how well they fulfill eligibility criteria. Don’t rush your application, but rather take your time to find your teammate, your coaches, and to choose the most suitable project for your team.  
@@ -125,13 +125,13 @@ Rails Girls Summer of Code will assist and support you with any of these require
 We strongly advise you to get acquainted with these requirements before and during application time. We will make sure they are complied with and will take steps in case of breaches.  
 If you have any questions about the above list, please <a href="mailto:summer-of-code@railsgirls.com">contact us</a>.
 
-<h3 id="volunteer-teams">A Note on Volunteer Teams</h3>
+<h3 id="volunteer-teams">A note on volunteer teams</h3>
 
 As well as the funded teams, every year the Rails Girls Summer of Code has also had a few selected volunteer teams. Volunteer teams are teams that participate in the program without the monthly stipend. 
 Volunteer teams adhere to the same guidelines as funded teams, and apart from the stipend they receive the same amount of support as the other teams, and are involved in the social activities. 
 Due to this, volunteer teams are also subjected to the selection process. In your application, you will have the option to select whether you are applying as a funded team, a volunteer team, or you can select both options. 
 
-<h3 id="volunteer-teams">Before You Apply: The Checklist</h3>
+<h3 id="volunteer-teams">Before you apply: the checklist</h3>
 
 Here is the basic checklist for your application:
 

--- a/students/findyourteam.md
+++ b/students/findyourteam.md
@@ -1,11 +1,11 @@
 ---
 layout: page
-title: How to find your team
+title: Finding your team
 class: page page-howto
 sidebar: content
 current: students
 current-sub: team
-permalink: /students/find-your-team/
+permalink: /students/finding-your-team/
 ---
 
 <h1>{{page.title}}</h1>

--- a/students/findyourteam.md
+++ b/students/findyourteam.md
@@ -1,0 +1,64 @@
+---
+layout: page
+title: How to find your team
+class: page page-howto
+sidebar: content
+current: students
+current-sub: team
+permalink: /students/find-your-team/
+---
+
+<h1>{{page.title}}</h1>
+
+Here is some info on putting together your team, including tips on finding coaches and a teammate.
+
+<ul>
+  <li><a href="#coaches">Coaches</a></li>
+    <ul>
+      <li><a href="#coach">What exactly is a coach?</a></li>
+      <li><a href="#find-coaches">Where do I find coaches?</a></li>
+      <li><a href="#coach-help">How available should my coaches be? How much should they help?</a></li>
+    </ul>
+  <li><a href="#teammate">Teammate</a></li>
+    <ul>
+      <li><a href="#good-teammate">What makes a suitable teammate?</a></li>
+      <li><a href="#find-teammate">Where do I find a teammate?</a></li>
+    </ul>
+</ul>
+
+<h3 id="coaches">Coaches</h3>
+
+<h4 id="coach">What exactly is a coach?</h4>
+
+Coaches are developers who sit down with you, guide you through relevant coding steps and troubleshoot with you at regular intervals. This is why we require them to be based in the same city as your team.
+
+<h4 id="find-coaches">Where do I find coaches?</h4>  
+
+A great place to start with this is with your local Rails Girls chapter or in local user groups relevant to the language of the project you wish to work on. 
+The organisers of these meetups are usually happy to give you a few minutes to do a small lightning talk where you explain RGSoC and what is involved in coaching, and ask if anyone there is interested in getting involved. 
+If you have no luck, or live in an area where there is no Rails Girls chapter and no user group, ask on <a href="https://groups.google.com/forum/#!forum/rails-girls-summer-of-code-community">the Rails Girls Summer of Code community mailing list</a>, or via <a href="https://www.twitter.com/railsgirlssoc">@RailsGirlsSoC</a> on Twitter.
+
+<h4 id="coach-help">How available should my coaches be? How much should they help?</h4>  
+
+From past experiences, we recommend 4-8 hours per week of coaching time. We require a minimum of 2 coaches so they can share the time commitment, and so you and your teammate have more flexible support.
+
+Coaches should be available to help during office hours at times where you get quite stuck with something. This doesn't have to be in person, and can be via email or a messaging app such as slack. 
+
+Already during application time, talk to them about how they communicate and how you can handle possible situations of stress and/or conflict as a team.
+
+<h3 id="teammate">Teammate</h3>
+
+<h4 id="good-teammate">What makes a suitable teammate?</h4>
+
+In the process of teaming up, keep in mind that you will be working very closely during the 3 months of the program. There will be situations of stress and conflict; this is nothing bad, it happens. However we strongly recommend to prepare for these situations by being open about yourself and offering self-reflective, constructive ways of communication — and to expect the same from your teammate. We also recommend to establish regular and dedicated team reflection times where you can talk about how you work together, what went well and what didn't.  
+It might also be that your future pair has different skills. Talk about your skill levels and how to handle possible disparities. Or you or your pair might be in a personal condition or life situation which could have an impact on your work as a team. We strongly suggest to mention these to the extent you feel comfortable about it, so your pair can react considerately. Also, be aware that other people work differently or handle moments of stress in different ways.  
+
+For the duration of the program we require that you work together in the same place, so this is also something to consider when trying to find a teammate.  
+
+<h4 id="find-teammate">Where do I find a teammate?</h4>
+
+A great place to start with this is with your local Rails Girls chapter. Speak to organisers and coaches from the group as they might know of someone who would also be interested in applying. If you regularly attend a study group, try asking there as well.
+Another suggestion is to attend, and speak to people in your local Ruby meetup group, (or other user groups relevant to whichever language prospective projects are in).
+If you have no luck, or live in an area where there is no Rails Girls chapter or no user group, ask on <a href="https://groups.google.com/forum/#!forum/rails-girls-summer-of-code-community">the Rails Girls Summer of Code community mailing list</a>, or via <a href="https://www.twitter.com/railsgirlssoc">@RailsGirlsSoC</a> on Twitter. We will happily connect and retweet you!
+
+

--- a/students/findyourteam.md
+++ b/students/findyourteam.md
@@ -42,9 +42,9 @@ If you have no luck, or live in an area where there is no Rails Girls chapter an
 
 From past experiences, we recommend 4-8 hours per week of coaching time. We require a minimum of 2 coaches so they can share the time commitment, and so you and your teammate have more flexible support.
 
-Coaches should be available to help during office hours at times where you get quite stuck with something. This doesn't have to be in person, and can be via email or a messaging app such as slack. 
+Coaches should be available to help during office hours at times where you get quite stuck with something. This doesn't have to be in person, and can be done via email or a messaging app such as slack. 
 
-Already during application time, talk to them about how they communicate and how you can handle possible situations of stress and/or conflict as a team.
+**An important note:** Already during application time, talk to them about how they communicate and how you can handle possible situations of stress and/or conflict as a team. This will definitely help you should any tricky situations arise. 
 
 <h3 id="teammate">Teammate</h3>
 
@@ -58,7 +58,7 @@ For the duration of the program we require that you work together in the same pl
 <h4 id="find-teammate">Where do I find a teammate?</h4>
 
 A great place to start with this is with your local Rails Girls chapter. Speak to organisers and coaches from the group as they might know of someone who would also be interested in applying. If you regularly attend a study group, try asking there as well.
-Another suggestion is to attend, and speak to people in your local Ruby meetup group, (or other user groups relevant to whichever language prospective projects are in).
+Another suggestion is to attend, and speak to people in your local Ruby meetup group — or other user groups relevant to whichever language prospective projects are in.
 If you have no luck, or live in an area where there is no Rails Girls chapter or no user group, ask on <a href="https://groups.google.com/forum/#!forum/rails-girls-summer-of-code-community">the Rails Girls Summer of Code community mailing list</a>, or via <a href="https://www.twitter.com/railsgirlssoc">@RailsGirlsSoC</a> on Twitter. We will happily connect and retweet you!
 
 


### PR DESCRIPTION
this adds the improved student application guide, including a separate page with tips for finding coaches and team mates, and updates the navigation accordingly. 
to-dos: would be great to maybe add screenshots from the application process when we have them, or illustrations.
