### PR TITLE
Update Sponsorship Guidelines

### DIFF
--- a/sponsors/sponsorship-guidelines.md
+++ b/sponsors/sponsorship-guidelines.md
@@ -48,4 +48,4 @@ If for some unforeseen reason the Rails Girls Summer of Code can’t go ahead as
 
 ## Left-over monies
 
-Any money left over from the campaign will be saved for next year’s Rails Girls Summer of Code. Should there be no Summer of Code in particular year, the Rails Girls organization will decide how to best spend any left over donation money on other non-profit initiatives.
+Any money left over from the campaign will be saved for next year’s Rails Girls Summer of Code. Should there be no Summer of Code next year, the Rails Girls organization will decide how to best spend any left over donation money on other non-profit initiatives.

--- a/sponsors/sponsorship-guidelines.md
+++ b/sponsors/sponsorship-guidelines.md
@@ -48,4 +48,4 @@ If for some unforeseen reason the Rails Girls Summer of Code can’t go ahead as
 
 ## Left-over monies
 
-Any money left over from the campaign will be saved for next year’s Rails Girls Summer of Code. Should there be no Summer of Code in 2016, the Rails Girls organization will decide how to best spend any left over donation money on other non-profit initiatives.
+Any money left over from the campaign will be saved for next year’s Rails Girls Summer of Code. Should there be no Summer of Code in particular year, the Rails Girls organization will decide how to best spend any left over donation money on other non-profit initiatives.


### PR DESCRIPTION
In [http://railsgirlssummerofcode.org/sponsorship-guidelines](url) 
last sentence changed from 

> Should there be no Summer of Code in **2016**, the Rails Girls organization will decide how to best spend any left over donation money on other non-profit initiatives.

to

> Should there be no Summer of Code in **particular year**, the Rails Girls organization will decide how to best spend any left over donation money on other non-profit initiatives.

With this change it won't be necessary to update year's number every time.

@ramonh 
