### PR TITLE
Team JaM - remove comments in the text to render page correctly

### DIFF
--- a/blog/_posts/2016-08-08-hello-team-jam.md
+++ b/blog/_posts/2016-08-08-hello-team-jam.md
@@ -40,7 +40,8 @@ Nick works at Mozilla, where he hacks on Firefox Developer tools and Spider Monk
 ### What are Rust and Servo?
 
 [Rust](https://doc.rust-lang.org/book/README.html) is a systems-level programming language that was started in 2010 by an employee at Mozilla. It is a compiled language, so creating executable code is slow, but runtime is fast. It is also memory safe, so pointers will only point to things that actually exist. Lastly, it is designed for concurrency and parallelism on multiple cores. You might consider using it for projects where you would otherwise write C++ code. Plus we think Rust is easier to read and write than C++.
-![rust-servo-doge](/img/blog/2016/team-jam-rust-servo.png)<font color="grey"><small><i>(photo: www.rust-lang.org/en-US/, www.servo.org)</i></small></font>
+
+![rust-servo-doge](/img/blog/2016/team-jam-rust-servo.png)<font color="grey"><small><i>(photo: malisa/jeena)</i></small></font>
 
 [Servo](https://servo.org/) is also Mozilla's baby. It is a parallel browser engine, and it is written in Rust! We are working on Servo this summer.
 
@@ -48,7 +49,8 @@ Nick works at Mozilla, where he hacks on Firefox Developer tools and Spider Monk
 
 <!-- malisa -->
 ### Our Project
-![fetch](/img/blog/2016/team-jam-make-fetch-happen.jpg)<font color="grey"><small><i></i></small>(photo: www.slate.com. edited by: Malisa)</font>
+![fetch](/img/blog/2016/team-jam-make-fetch-happen.jpg)<font color="grey"><small><i>(photo: www.rust-lang.org/en-US/, www.servo.org)</i></small></font>
+
 Within the vast codebase that is Servo, our task is to implement the Fetch API. The Fetch API sends an HTTP Request, [similar to XMLHttpRequest](https://developers.google.com/web/updates/2015/03/introduction-to-fetch). We are writing the Fetch API in Rust and connecting it to the JavaScript task.
 
 Sending an HTTP Request via the Fetch API involves a request and a response. Our task is to follow the class templates for Request, Response, Headers, and Fetch, which are specified by the [WHATWG standards for the Fetch API](https://fetch.spec.whatwg.org/). We're lucky to have very specific instructions and goals for our project. ;)

--- a/blog/_posts/2016-08-08-hello-team-jam.md
+++ b/blog/_posts/2016-08-08-hello-team-jam.md
@@ -23,7 +23,6 @@ I spent about half of my life in South Korea, and the other half in the West Coa
 
 I always welcome learning opportunities, so please reach out to me through my [blog](http://jeenalee.com/) or [twitter](https://twitter.com/theJeenaLee)!
 
-<!-- malisa -->
 **Malisa**:
 I've spent most of my life in Seattle and Pennsylvania, with bits here and there in Long Island, New Zealand, and Japan. I really love Portland so far! I majored in Biology as an undergrad, but I've always wanted to study more computer science because of its emphasis on problem solving and algorithms. To that end, a little over a year ago I decided to get my Master's in bioinformatics, and since then I've been coding full-time. I'm super excited to have an opportunity to broaden my programming skills this summer with RGSoC.
 
@@ -36,7 +35,6 @@ Stefan works at Oregon Health and Science University, helping researchers and do
 
 Nick works at Mozilla, where he hacks on Firefox Developer tools and Spider Monkey. On the weekends, you can find him playing bike polo.
 
-<!-- malisa -->
 ### What are Rust and Servo?
 
 [Rust](https://doc.rust-lang.org/book/README.html) is a systems-level programming language that was started in 2010 by an employee at Mozilla. It is a compiled language, so creating executable code is slow, but runtime is fast. It is also memory safe, so pointers will only point to things that actually exist. Lastly, it is designed for concurrency and parallelism on multiple cores. You might consider using it for projects where you would otherwise write C++ code. Plus we think Rust is easier to read and write than C++.
@@ -47,10 +45,9 @@ Nick works at Mozilla, where he hacks on Firefox Developer tools and Spider Monk
 
 ...what is a browser engine anyway? To generalize, a browser engine takes a URL and displays the document that corresponds to it. Every web browser has one. For example, Firefox's current browser engine is called Gecko and is written in C++. Mozilla's long-term plan is to replace bits of Gecko with bits of Servo. You can read more about browser engines [here](https://en.wikipedia.org/wiki/Web_browser_engine#Technical_operation).
 
-<!-- malisa -->
 ### Our Project
 
-![fetch](/img/blog/2016/team-jam-make-fetch-happen.jpg)<font color="grey"><small><i></i></small>(photo: www.slate.com. edited by: Malisa)</font>
+![fetch](/img/blog/2016/team-jam-make-fetch-happen.jpg)<font color="grey"><small><i>(photo: www.slate.com. edited by: Malisa)</i></small></font>
 
 Within the vast codebase that is Servo, our task is to implement the Fetch API. The Fetch API sends an HTTP Request, [similar to XMLHttpRequest](https://developers.google.com/web/updates/2015/03/introduction-to-fetch). We are writing the Fetch API in Rust and connecting it to the JavaScript task.
 
@@ -70,7 +67,6 @@ Probably even more exciting is the influence that this project has had on *us*.
 - On a related note, working on such a big project with such an unfamiliar codebase and lots of contributors is a very valuable experience. Good documentation and collaboration etiquette is appreciated by everybody.
 - Plus this is the first time we've even heard that web browser engines exist!
 
-<!-- together -->
 ### What tips do we want to share?
 - Document your daily learnings with TIL ("today I learned"). When you feel like you're not making progress, go through your TILs and realize how far you have come!
 - Be vocal about your thoughts, especially when pair-programming. Other people sadly cannot read your mind.

--- a/blog/_posts/2016-08-08-hello-team-jam.md
+++ b/blog/_posts/2016-08-08-hello-team-jam.md
@@ -41,7 +41,7 @@ Nick works at Mozilla, where he hacks on Firefox Developer tools and Spider Monk
 
 [Rust](https://doc.rust-lang.org/book/README.html) is a systems-level programming language that was started in 2010 by an employee at Mozilla. It is a compiled language, so creating executable code is slow, but runtime is fast. It is also memory safe, so pointers will only point to things that actually exist. Lastly, it is designed for concurrency and parallelism on multiple cores. You might consider using it for projects where you would otherwise write C++ code. Plus we think Rust is easier to read and write than C++.
 
-![rust-servo-doge](/img/blog/2016/team-jam-rust-servo.png)<font color="grey"><small><i>(photo: malisa/jeena)</i></small></font>
+![rust-servo-doge](/img/blog/2016/team-jam-rust-servo.png)<font color="grey"><small><i>(photo: www.rust-lang.org/en-US/, www.servo.org)</i></small></font>
 
 [Servo](https://servo.org/) is also Mozilla's baby. It is a parallel browser engine, and it is written in Rust! We are working on Servo this summer.
 
@@ -49,7 +49,8 @@ Nick works at Mozilla, where he hacks on Firefox Developer tools and Spider Monk
 
 <!-- malisa -->
 ### Our Project
-![fetch](/img/blog/2016/team-jam-make-fetch-happen.jpg)<font color="grey"><small><i>(photo: www.rust-lang.org/en-US/, www.servo.org)</i></small></font>
+
+![fetch](/img/blog/2016/team-jam-make-fetch-happen.jpg)<font color="grey"><small><i></i></small>(photo: www.slate.com. edited by: Malisa)</font>
 
 Within the vast codebase that is Servo, our task is to implement the Fetch API. The Fetch API sends an HTTP Request, [similar to XMLHttpRequest](https://developers.google.com/web/updates/2015/03/introduction-to-fetch). We are writing the Fetch API in Rust and connecting it to the JavaScript task.
 


### PR DESCRIPTION
We noticed that the markdown wasn't rendering correctly. This PR will correct that.
