### PR TITLE
Update the press page information and add new sections

### DIFF
--- a/about/press.html
+++ b/about/press.html
@@ -12,11 +12,11 @@ permalink: /about/press/
       </p>
 
       <p>
-      Since 2013, over 580 women all over the world have applied and up to this date, RGSoC has supported 106 students — with a total of 35 sponsored teams and 20 volunteering teams. Recently, a survey conducted by RGSoC revealed that 90% of the students are still working in tech and 8% have founded their startups. 55% of those students still regularly contribute to Open Source projects.
+      Since 2013, over 580 women all over the world have applied and up to this date, RGSoC has supported 146 students — with a total of 51 sponsored teams and 24 volunteering teams. Recently, a survey conducted by RGSoC revealed that 90% of the students are still working in tech and 8% have founded their startups. 55% of those students still regularly contribute to Open Source projects.
       </p>
 
       <p>
-      In 2016, over 90 teams applied for the program, almost doubling RGSoC 2015’s record! So far, 44 Open Source projects were accepted for this edition and 12 teams will be funded. All selected teams, including volunteer teams, will be announced at the beginning of June. Meanwhile, RGSoC has launched the <a href="http://railsgirlssummerofcode.org/blog/2016-04-22-thank-you-lets-diversify-tech">#diversifytech</a> campaign to thank all of the people who have contributed to the program.
+      In 2016, over 90 teams applied for the program, almost doubling RGSoC 2015’s record! So far, 44 Open Source projects were accepted for this edition and 20 teams were selected. All selected teams, including volunteer teams, <a href="http://railsgirlssummerofcode.org/blog/2016-07-01-RGSoC-2016-day-one">were announced</a> at the beginning of June. Meanwhile, RGSoC has launched the <a href="http://railsgirlssummerofcode.org/blog/2016-04-22-thank-you-lets-diversify-tech">#diversifytech</a> campaign to thank all of the people who have contributed to the program.
       </p>
 
       <p>
@@ -34,7 +34,7 @@ permalink: /about/press/
         <li><strong>08/12-01/02:</strong> Call for Projects</li>
         <li><strong>22/02:</strong> Crowdfunding opens</li>
         <li><strong>17/03:</strong> Applications open</li>
-        <li><strong>10/04:</strong> Applications close!</li>
+        <li><strong>10/04:</strong> Applications close</li>
         <li><strong>End of May:</strong> Acceptance letters</li>
         <li><strong>01/07:</strong> Kickoff RGSoC 2016!</li>
         <li><strong>30/09:</strong> Last day of RGSoC 2016</li>
@@ -61,3 +61,4 @@ permalink: /about/press/
       <h3>Press Releases & Media</h3>
 
       <p>Coming soon. </p>
+      


### PR DESCRIPTION
Follow up on https://github.com/rails-girls-summer-of-code/summer-of-code/issues/199

@ramonh I just created this PR for us to start adding the new info, press releases and images. I also was thinking about adding a section "What they say about us, like we had on the RGSoC 2013 Press Page, but by sections, like students, coaches, companies.

RGSoC 2013 Press Page
http://2013.railsgirlssummerofcode.org/press/

Slack's press page
https://brandfolder.com/slack

Offscreen about page
http://www.offscreenmag.com/about/
