### PR TITLE
Sort Teams by name and display them in rows

### DIFF
--- a/about/current-students.html
+++ b/about/current-students.html
@@ -8,7 +8,6 @@ permalink: /about/students/
 ---
 <section class="main container">
     <div class="wrapper clearfix">
-      <h1>2016 Students</h1>
       <article id="js-students" class="is-loading">
 
       </article>

--- a/assets/javascripts/current-students.js
+++ b/assets/javascripts/current-students.js
@@ -17,7 +17,8 @@ CurrentStudents.prototype = {
 			.done(function(data) {
 				this.queryData = data;
 				self.getStudentsPerTeam(this.queryData);
-				self.buildPage(this.queryData);
+				self.sortTeamsByName();
+				self.buildPage();
 				$('.is-loading').removeClass('is-loading');
 
 			}).fail(function() {
@@ -30,7 +31,7 @@ CurrentStudents.prototype = {
 		$.each(data, function(k, v) {
 			// Structure for this array:
 			// [{teamName: name, teamMembers: [{respective students from data}]}]
-			var teamName = v.roles[0].team.name;
+			var teamName = v.roles[0].team.name.trim();
 
 			// empty variable, which is filled in the for loop and
 			// used in the if statement
@@ -51,17 +52,27 @@ CurrentStudents.prototype = {
 			// else: create a new object inside the teams-array
 			if (existingTeam) {
 				existingTeam.Members.push(v);
-			}else {
+			} else {
 				var team = {Name: teamName, Members: [v]};
 				self.teams.push(team);
 			}
 		});
 	},
-	buildPage: function(data) {
+
+	sortTeamsByName: function() {
+		var self = this;
+		self.teams.sort(self.compareNames);
+	},
+
+	compareNames: function(a, b) {
+		var opts = {sensitivity:'base'};
+		return a.Name.localeCompare(b.Name, 'en', opts);
+	},
+
+	buildPage: function() {
 		var self = this;
 		var output = '';
 		var avatar = '';
-		console.log(this.teams);
 		// Structure is:
 		// [{teamName: name, teamMembers: [{respective students from data}]}]
 		$.each(this.teams, function(k, v) {

--- a/assets/javascripts/current-students.js
+++ b/assets/javascripts/current-students.js
@@ -75,8 +75,12 @@ CurrentStudents.prototype = {
 		var avatar = '';
 		// Structure is:
 		// [{teamName: name, teamMembers: [{respective students from data}]}]
+		output += '<h2> 2016 Students </h2>';
+		output += '<div class="students-container">';
+
 		$.each(this.teams, function(k, v) {
-			output += '<h2>'+ 'Team ' + v.Name +'</h2>';
+			output += '<div class="students-item">';
+			output += '<h4>'+ 'Team ' + v.Name +'</h4>';
 			output += '<ul class="list--none list--team Grid--5">';
 			$.each(v.Members, function(key, val) {
 				if(val.avatar_url === null) {
@@ -95,7 +99,9 @@ CurrentStudents.prototype = {
 				output += '</p></figcaption></li>';
 			});
 			output += '</ul>';
+			output += '</div>';
 		});
+    output += '</div>';
 		$('#js-students').append(output);
 	},
 };

--- a/assets/stylesheets/team.scss
+++ b/assets/stylesheets/team.scss
@@ -13,7 +13,9 @@
   text-align: center;
 }
 .list--team figure img {
-  width: 60%;
+  width: 10vw;
+  max-width: 12rem;
+  min-width: 60%;
   border-radius: 50%;
   overflow: hidden;
 }
@@ -42,4 +44,22 @@
   background-image: url('../../../img/ajax-loader.gif');
   background-repeat: no-repeat;
   background-position: center;
+}
+
+/*
+ * Student grid
+ */
+#js-students {
+  h2 {
+    margin-top: floor(($font-size-h1 * $headings-line-height)); // 64px
+  }
+  .students-container {
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: space-between;
+    .students-item {
+      text-align: center;
+      width: 300px;
+    }
+  }
 }


### PR DESCRIPTION
This adds the improvements from #301:
* sort teams by name (using the English alphabet)
* display multiple teams in a row

I also had to slighly adapt the *"teams"* as in *orga-team* styling to be able to use it with the grid-like new *students-team* page. The behavior is still the same though. Plus I slightly adapted the *students-team* layout to more resemble the *orga-team* one.

Hope that's fine.

 _(PS: The JS files use tabs instead of spaces 🙈 )_