### PR TITLE
create a redirect to fix issue with bad permalink campaign post

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,5 +7,6 @@ defaults:
   category: 'news'
 gems:
   - jekyll-paginate
+  - jekyll-redirect-from
 paginate: 5
 paginate_path: /blog/page/:num

--- a/blog/_posts/2017-02-16-anniversary-campaign.md
+++ b/blog/_posts/2017-02-16-anniversary-campaign.md
@@ -1,8 +1,9 @@
 ---
+redirect_from: "/blog/2016-02-16-anniversary-campaign"
 title: Our Anniversary campaign is open - Celebrate with us!
 layout: post
 created_at: Fri February 17 2017
-permalink: blog/2016-02-16-anniversary-campaign
+permalink: blog/2017-02-16-anniversary-campaign
 author: Anika
 twitter: RailsGirlsSoc
 categories:


### PR DESCRIPTION
I've taken a look at how to create redirects with [github-pages](https://help.github.com/articles/redirects-on-github-pages/) and this PR should fix the “bad” permalink in the latest campaign blog post (with year `2016` instead of `2017`). 
It seems to work seamlessly locally: when someone clicks on the old link (2016) they get redirected to a new link (2017).