### PR TITLE
Add categories to blog posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,6 +15,22 @@ layout: bootstrap
           {{ page.author }}
         {% endif %}
       </p>
+      {% if page.categories && page.categories > 0 %}
+        <p class="meta categories">Categories: 
+          {% for category in page.categories %}
+            <span class="tag">
+                {% if forloop.last == true %} 
+                  and 
+                {% else %}
+                  {% if forloop.first == false %}
+                    , 
+                  {% endif %}
+                {% endif %}
+                <a href="/blog/categoryview/#{{ category }}">{{ category }}</a>
+            </span>
+          {% endfor %}
+        </p>
+      {% endif %}
       {{ content }}
       <div class="blog-share">
         <div class="shariff" data-services="[&quot;twitter&quot;,&quot;facebook&quot;,&quot;googleplus&quot;]" data-lang="en"></div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,13 +20,17 @@ layout: bootstrap
           {% for category in page.categories %}
             <span class="tag">
                 {% if forloop.last == true %} 
-                  and 
+                  <span class="lowercase">and</span>
                 {% else %}
                   {% if forloop.first == false %}
                     , 
                   {% endif %}
                 {% endif %}
-                <a href="/blog/categoryview/#{{ category }}">{{ category }}</a>
+                {% if category == 'blog' %}
+                <a href="/blog">{{ category }}</a>
+                {% else %}
+                <a href="/blog/categoryview/#{{ category }}">{{ category | replace:'-',' ' }}</a>
+                {% endif %}
             </span>
           {% endfor %}
         </p>

--- a/assets/stylesheets/blog.scss
+++ b/assets/stylesheets/blog.scss
@@ -10,6 +10,12 @@
   .meta.categories {
     margin-top:-15px;
     font-size: 80%;
+    .tag {
+      text-transform:capitalize;
+    }
+    .lowercase {
+      text-transform: lowercase;
+    }
   }
   img {
     width: 100%;

--- a/assets/stylesheets/blog.scss
+++ b/assets/stylesheets/blog.scss
@@ -7,6 +7,10 @@
       text-decoration: underline;
     }
   }
+  .meta.categories {
+    margin-top:-15px;
+    font-size: 80%;
+  }
   img {
     width: 100%;
     height: auto;


### PR DESCRIPTION
Addresses Issue #211 

This adds the categories of a blog post to the meta display just below the Posted on and Author information.  

![image](https://user-images.githubusercontent.com/1408372/30566339-dc11fb12-9c88-11e7-9417-8173084976be.png)

The categories link to the categoryview anchor tag unless it is the main `blog` category.  This had to stay in for now since it would mess up the insertion of commas and 'and'.  Since it did not have an anchor tag on the categoryview page, I liked it back to the main blog page.