### PR TITLE
Blog category updates

### DIFF
--- a/_includes/blog_sidebar.html
+++ b/_includes/blog_sidebar.html
@@ -36,7 +36,22 @@
         <li><a href="{{ post.url }}">{{ post.title }}</a></li>
       {% endfor %}
     </ul>
-    <p>See all posts in the <a href="/blog/archive/">archive</a> or <a href="/blog/categoryview">browse by category</a>!</p>
+    <p>See all posts in the <a href="/blog/archive/">archive</a> <!-- or <a href="/blog/categoryview">browse by category</a>!--></p>
+    <h3 class="l-sidebar__heading">Browse by category</h3>
+    {% assign categories = site.categories | sort %}
+      <ul class="list list--none">
+      {% for category in categories %}
+        {% if category[0] != 'blog' %}
+          <span class="site-tag">
+            <li>
+              <a href="#{{ category | first | slugify }}">
+                    {{ category[0] | replace:'-', ' ' }} ({{ category | last | size }})
+              </a>
+            </li>
+          </span>
+        {% endif %}
+      {% endfor %}
+    </ul>
   </div>
   <section>
     <h3  class="l-sidebar__heading">Latest tweets</h3>

--- a/_includes/blog_sidebar.html
+++ b/_includes/blog_sidebar.html
@@ -44,7 +44,7 @@
         {% if category[0] != 'blog' %}
           <span class="site-tag">
             <li>
-              <a href="#{{ category | first | slugify }}">
+              <a href="/blog/categoryview/#{{ category | first | slugify }}">
                     {{ category[0] | replace:'-', ' ' }} ({{ category | last | size }})
               </a>
             </li>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -23,7 +23,7 @@ layout: bootstrap
                   <span class="lowercase">and</span>
                 {% else %}
                   {% if forloop.first == false %}
-                    , 
+                  <span class="cat-comma">, </span>
                   {% endif %}
                 {% endif %}
                 {% if category == 'blog' %}

--- a/assets/stylesheets/blog.scss
+++ b/assets/stylesheets/blog.scss
@@ -99,3 +99,7 @@
     width: 200px
   }
 }
+
+.cat-comma {
+  margin-left: -2px;
+}


### PR DESCRIPTION
@alicetragedy I took a look at those other two issues and found a fix for both.  

For the first, I assumed you meant someplace in the sidebar, so I moved the category listings there.  They still link to the categoryview anchor tags, but will allow users to quickly navigate to posts just in a category.

For the comma issue... yeah I agree that is a weird one. I'm not sure where that space is coming from.  After investigating, it looks like it is actually helping us for the 'and' one, so I didn't want to nuke it (even if I could).  I ended up adding a css hack (`margin-left:-2px`) for the comma which seems to have corrected the issue at least visually.  
Hope these are helpful!
Chris