### PR TITLE
duplicate 2018 data files

### DIFF
--- a/_data/conferences.2018.yaml
+++ b/_data/conferences.2018.yaml
@@ -1,0 +1,72 @@
+- name: FullStackFest
+  id: full-stack-fest
+  url: https://fullstackfest.com/
+  dates:
+    - September 3-7, 2018
+  location: Barcelona, Spain
+  twitter_url: https://twitter.com/fullstackfest
+  twitter_name: fullstackfest
+  img: /img/blog/2018/conferences/fullstack.png
+- name: GOTO Berlin 2018
+  id: goto-berlin
+  url: https://gotober.com/
+  dates:
+    - October 29 - November 2, 2018
+  location: Berlin, Germany
+  twitter_url: https://twitter.com/gotober
+  twitter_name: gotober
+  img: /img/blog/2018/conferences/goto_berlin.png
+- name: MirrorConf
+  id: mirror-conf
+  url: https://www.mirrorconf.com/
+  dates:
+    - October 15-19, 2018
+  location: Braga, Portugal
+  twitter_url: https://twitter.com/MirrorConf
+  twitter_name: MirrorConf
+  img: /img/blog/2018/conferences/mirror-conf-square.png
+- name: GoLab
+  id: go-lab
+  url: https://www.golab.io/
+  dates:
+    - October 22-23, 2018
+  location: Florence, Italy
+  twitter_url: https://twitter.com/golab_conf
+  twitter_name: golab_conf
+  img: /img/blog/2018/conferences/golab.jpg
+- name: Open Source Summit Europe
+  id: oss-europe
+  url: https://events.linuxfoundation.org/events/open-source-summit-europe-2018/
+  dates:
+    - October 22-24, 2018
+  location: Edinburgh, UK
+  twitter_url: https://twitter.com/linuxfoundation
+  twitter_name: linuxfoundation
+  img: /img/blog/2018/conferences/oss-europe.png
+- name: reactjsday
+  id: reactjsday
+  url: https://2018.reactjsday.it/
+  dates:
+    - October 5th, 2018
+  location: Verona, Italy
+  twitter_url: https://twitter.com/reactjsday
+  twitter_name: reactjsday
+  img: /img/blog/2018/conferences/reactjsday.jpg
+- name: GHCI, 2018
+  id: ghci
+  url: https://ghcindia.anitab.org/
+  dates:
+    - November 14th - 16th, 2018
+  location: Bangalore, India
+  twitter_url: https://twitter.com/AnitaBorg_India
+  twitter_name: AnitaBorg_India
+  img: /img/blog/2018/conferences/anita_borg.jpg
+- name: Frontend Conference Fukuoka 2018
+  id: frontend-conference-fukuoka
+  url: https://frontend-conf.fukuoka.jp
+  dates:
+    - December 8th, 2018
+  location: Fukuoka, Japan
+  twitter_url: https://twitter.com/fec_fukuoka
+  twitter_name: fec_fukuoka
+  img: /img/blog/2018/conferences/fec_fukuoka.jpg

--- a/_data/packages.2018.yaml
+++ b/_data/packages.2018.yaml
@@ -1,0 +1,467 @@
+- name: Partners
+  title: Partner Companies
+  sponsors:
+  - name: Travis CI
+    id: travis
+    url: https://travis-ci.com
+    partner: true
+    text: |-
+      <a href="https://travis-ci.com" target="_blank">Travis CI</a> is a hosted continuous integration service 
+      created in 2011 to serve the Open Source community from which it began. Integrated with GitHub, 
+      Travis CI offers first class support to many programming languages including Python, Go, PHP, Java, C++, and Ruby. 
+      Travis CI also launched <a
+      href="http://foundation.travis-ci.org">Travis Foundation</a>, a non-profit organization which aims to make 
+      Open Source a diverse and inclusive place. One of Travis Foundation’s main efforts is Rails Girls Summer of Code which 
+      helps individuals from underrepresented groups begin their careers in programming. 
+    years:
+      - 2013
+      - 2014
+      - 2015
+      - 2016
+      - 2017
+      - 2018
+  - name: GitHub
+    id: github
+    url: https://github.com
+    partner: true
+    text: |-
+      <a href="https://github.com" target="_blank">GitHub</a> is how people build software. Millions of individuals and 
+      organizations around the world use GitHub to discover, share, and collaborate on software-from games and experiments 
+      to popular frameworks and leading applications. Together, we're defining how software is built today.
+
+      Whether you use GitHub.com or GitHub Enterprise on your own servers, you can access one of the world's largest 
+      developer communities to build software in the way that works best for you. Choose your deployment option and 
+      integrate your favorite third-party tools into a powerful, collaborative workflow.
+    years:
+      - 2013
+      - 2014
+      - 2015
+      - 2016
+      - 2017
+      - 2018
+
+- name: Platinum
+  title: Platinum Sponsors
+  sponsors:
+    - name: Electra
+      id: electra
+      url: https://electraproject.org/
+      text: |-
+        <a href="https://electraproject.org/" target="_blank">Electra</a> is more than just a cryptocurrency, 
+        it is an open source community-driven project focused on transparency and the needs of the community. 
+        Through the combination of blockchain technology and community, Electra aims to be an ever-evolving 
+        global payment system through the creation of a communal financial ecosystem. The fellowship of any 
+        community is empowered by diversity. Due to diversity and community being so closely intertwined, 
+        RGSoC came to our attention, as our values and our commitment to technological advancement parallel 
+        one another. Both of our projects operate within a talented and diverse set of community members 
+        seeking to involve more people in the world of technology.
+      years:
+        - 2018
+
+#- name: Gold
+#  title: Gold Sponsors
+#  sponsors:
+
+- name: Silver
+  title: Silver Sponsors
+  sponsors:
+    - name: Discourse
+      id: discourse
+      url: https://www.discourse.org/
+      text: |-
+        <a href="https://www.discourse.org" target="_blank">Discourse</a> is the 100% open source discussion platform built for the next decade of the Internet. 
+        Use it as a mailing list, discussion forum, long-form chat room, and more!
+      years:
+        - 2018
+    - name: Thoughtworks
+      id: thoughtworks
+      url: https://www.thoughtworks.com
+      text: |-
+        <a href="https://www.thoughtworks.com" target="_blank">ThoughtWorks</a> is a
+        software company and a community of passionate, purpose-led individuals. We
+        think disruptively to deliver technology to address our clients' toughest
+        challenges, all while seeking to revolutionize the IT industry and create
+        positive social change.
+      years:
+        - 2014
+        - 2015
+        - 2016
+        - 2017
+        - 2018
+    - name: INNOQ
+      id: innoq
+      url: https://www.innoq.com
+      text: |-
+        <a href="https://www.innoq.com" target="_blank">INNOQ</a> is a software consultancy 
+        and delivers successful software solutions, infrastructure and business models. 
+        We value innovative thinking and a passion for software development. We are a supporter 
+        of Rails Girls Summer of Code since 2013 because we want to help increase diversity in 
+        the tech industry and the Open Source community.
+      years:
+        - 2013
+        - 2014
+        - 2015
+        - 2016
+        - 2017
+        - 2018
+    - name: RubyMotion
+      id: rubymotion
+      url: http://www.rubymotion.com/
+      text: |-
+        <a href="http://www.rubymotion.com/" target="_blank">RubyMotion</a> gives you the power to build native cross-platform 
+        apps for iOS, Android, and MacOS. Community empowerment is one of the company's core guiding principles. 
+        Supporting RGSoC was simply a no-brainer :-)
+      years: 
+        - 2018
+    - name: Bitcrowd
+      id: bitcrowd
+      url: https://bitcrowd.net/en
+      text: |-
+        <a href="https://bitcrowd.net/en" target="_blank">Bitcrowd</a> is a Berlin-based software agency with a strong focus on quality, client-interaction and people.
+        We care about the community and are happy to support RGSoC in diversifying tech!
+      years:
+        - 2017
+        - 2018
+    - name: Mapbox
+      id: mapbox
+      url: https://www.mapbox.com
+      text: |-
+        <a href="https://www.mapbox.com">Mapbox</a> is changing the way people move around cities and explore our world. 
+        Through the apps Mapbox powers, we reach more than 300 million people each month. 
+        We've architected the foundational parts of the mapping stack and are now poised for radical growth; 
+        we're looking for diverse team members to build the next layer together. We craft beautiful maps and 
+        developer-friendly location data, APIs, and SDKs so that you're free to focus on designing, building, 
+        and developing your application. Mapbox proudly embraces our open-source roots. 
+        We work in the open and release as much code as possible. We believe it's the right thing for people, 
+        technology, and business.
+      years:
+        - 2015
+        - 2016
+        - 2018
+    - name: Mozilla
+      id: mozilla
+      url: https://www.mozilla.org
+      text: |-
+        At <a href="https://www.mozilla.org">Mozilla</a>, we’re a global community of technologists,
+        thinkers and builders working together so people worldwide can be informed contributors and creators 
+        of the Web. Our mission is to ensure the Internet is a global public resource, open and accessible to all, 
+        where individuals can shape their own experience and are empowered, safe and independent. We support
+        RGSoC to empower more women to be part of our mission.
+      years:
+        - 2016
+        - 2017
+        - 2018
+    - name: Amazon Web Services
+      id: aws
+      url: https://aws.amazon.com
+      text: |-
+        For more than 11 years, <a href="https://aws.amazon.com">Amazon Web Services</a> has been the world's most 
+        comprehensive and broadly adopted cloud platform. AWS offers over 100 fully featured services for compute, 
+        storage, databases, networking, analytics, machine learning and artificial intelligence (AI), 
+        Internet of Things (IoT), mobile, security, hybrid, virtual and augmented reality (VR and AR), media, and 
+        application development, deployment, and management from 49 Availability Zones (AZs) across 18 geographic 
+        regions in the U.S., Australia, Brazil, Canada, China, France, Germany, India, Ireland, Japan, Korea, Singapore, and the UK. 
+        AWS services are trusted by millions of active customers around the world-including the fastest-growing startups, 
+        largest enterprises, and leading government agencies-to power their infrastructure, make them more agile, 
+        and lower costs. 
+      years:
+        - 2018
+
+- name: Bronze
+  title: Bronze Sponsors
+  sponsors:
+    - name: Loco2
+      id: loco2
+      url: https://loco2.com/
+      text: |-
+        Award-winning <a href="https://loco2.com" target="_blank">Loco2</a> is the only search and 
+        booking engine for domestic UK train travel that also covers Europe. Loco2 was the first booking 
+        platform to enable users to buy train tickets for domestic and long-distance travel in 
+        and around the UK and Europe in a single transaction, and still is today. It launched in 2012. 
+        We are passionate about promoting diversity in the tech industry and are delighted 
+        to have the opportunity to support RGSoC!
+      years:
+        - 2018
+
+    - name: Les Tilleuls
+      id: lestilleuls
+      url: https://les-tilleuls.coop/en
+      text: |-
+        <a href="https://les-tilleuls.coop" target="_blank">Les-Tilleuls.coop</a> is a French self-managed worker cooperative. 
+        Creators of the API Platform framework, we help our customers leveraging Open Source
+        solutions (API Platform, Symfony, React, Kubernetes, Node, Go...) and offer
+        a broad range of services including development, consulting, training and
+        software architecture. Our company is 100% owned and governed directly by
+        its 25 employees. Respect for others, tolerance and diversity are core
+        values upheld and defended by our employees. It seemed obvious to us to
+        support and mentor the RGSoC program and we would be delighted to give the
+        opportunity for women to work on an open source project.
+      years: 
+        - 2018
+
+    - name: Ableton
+      id: ableton
+      url: https://www.ableton.com/en/about/
+      text: |-
+        <a href="https://www.ableton.com/en/about/">Ableton</a> builds music software
+        and hardware that is used by a community of dedicated musicians, sound
+        designers and artists from across the world. Open source lifts the distinction
+        between producers and consumers of technology, unleashing a creative explosion
+        at the boundary between art and engineering. We support RGSoC because the best
+        results are achieved by richly diverse teams, and thus able to explore problems
+        from a wide set of perspectives.
+      years:
+        - 2016
+        - 2017
+        - 2018
+ 
+    - name: GitLab
+      id: gitlab
+      url: https://about.gitlab.com
+      text: |-
+        <a href="https://about.gitlab.com/">GitLab</a> is a community project primarily
+        written in Ruby on Rails. Over 1000 people worldwide have contributed! GitLab
+        Inc. is an active participant in this community, and we support organizations
+        and individuals using GitLab.  Our team is distributed across the globe, and
+        we're always growing. We're excited to sponsor RGSoC to
+        help get more women involved in Rails.
+      years:
+        - 2016
+        - 2017
+        - 2018
+    - name: Fedora
+      id: fedora
+      url: https://getfedora.org/
+      text: |-
+        The <a href="https://getfedora.org/">Fedora Project</a> is a community of people 
+        working together to build a free and open source software platform and to collaborate 
+        on and share user-focused solutions built on that platform. Or, in plain English, 
+        we make an operating system and we make it easy for you do useful stuff with it.
+      years:
+        - 2018
+    - name: ActBlue
+      id: actblue
+      url: https://actblue.com/
+      text: |-
+        <a href="https://actblue.com">ActBlue</a> builds and maintains a powerful, modern 
+        online fundraising platform for Democratic campaigns, progressive organizations, 
+        and nonprofits working to create a better future. We're supporting RGSoC because 
+        we want to help women find innovative solutions to the world's biggest problems.
+      years:
+        - 2015
+        - 2016
+        - 2017
+        - 2018
+
+    - name: Bendyworks
+      id: bendyworks
+      url: https://bendyworks.com
+      text: |-
+        <a href="https://bendyworks.com/" target="_blank">Bendyworks</a> delivers
+        high-value consulting, resulting in software that can flex in the face of
+        changing business needs. They are composed exclusively of creative and involved
+        programmers who dedicate themselves to sharing joy and success in their craft.
+        Bendyworks is thrilled to once again support Rails Girls Summer of Code.
+      years:
+        - 2013
+        - 2015
+        - 2016
+        - 2017
+        - 2018
+
+    - name: Runtastic
+      id: runtastic
+      url: https://runtastic.com/
+      text: |-
+        As Runtastics, we want every individual to live a more aware and active
+        lifestyle with our products, leading to a longer, happier life! Our
+        engineering team with people from <strong>all over the world</strong> plays a vital role
+        in making this a reality. We build large-scale services to support our
+        ever-growing user base of <strong>150+ million</strong> in our mobile apps and on
+        <a href="https://runtastic.com/" target="_blank">Runtastic.com</a>, 
+        leveraging open source technologies.  
+        It's a pleasure for us to get the chance to support the open source
+        community through RGSoC's unique mission.
+      years: 
+        - 2017
+        - 2018
+    - name: Basecamp
+      id: basecamp
+      url: https://basecamp.com
+      text: |-
+        <a href="https://basecamp.com/">Basecamp</a> is the world's #1 project
+        management tool. We make it easy for people in different roles with different
+        responsibilities to communicate and work together. Basecamp is proud to support RGSoC 2018 because we believe in fostering a supportive space for
+        women in the open source community. Ruby on Rails is the heart and soul of
+        Basecamp, and we wouldn't exist without contributions from people like 
+        Rails Girls!
+      years:
+        - 2013
+        - 2014
+        - 2015
+        - 2016
+        - 2017
+        - 2018
+    - name: Wooga
+      id: wooga
+      url: http://www.wooga.com
+      text: |-
+        Founded in 2009, Wooga has become one of the most popular developers of casual 
+        mobile games in the world. Based in Berlin, employees from around the world 
+        develop high quality casual games with engaging stories at the core of the experience. 
+        Wooga's aim is to play a memorable and positive part in people's lives and create 
+        joyful moments they look forward to playing everyday. 
+        Find out more at <a href="http://www.wooga.com/" target="_blank">www.wooga.com</a>.
+
+      years:
+        - 2013
+        - 2014
+        - 2015
+        - 2016
+        - 2017
+        - 2018
+    - name: Articulate
+      id: articulate
+      url: https://www.articulate.com
+      text: |-
+        Trusted by 78,000+ organizations worldwide, <a href="https://www.articulate.com/" target="_blank">Articulate</a>
+        software, services, community, and content make it easy to create compelling
+        courses for every device. <a href="https://www.articulate.com/" target="_blank">Articulate</a>
+        360 makes every aspect of e‑learning course development simpler, faster, and
+        less expensive. Articulate 360 has everything course developers need for every
+        aspect of e‑learning course development.
+      years:
+        - 2014
+        - 2015
+        - 2016
+        - 2017
+        - 2018
+    - name: Cobot 
+      id: cobot
+      url: https://www.cobot.me
+      text: |-
+       <a href="https://www.cobot.me">Cobot</a> is the leading management platform for coworking spaces. Our software help 
+       spaces ranging from small creative shared studios in Berlin over rural workspaces 
+       in the countryside of France to large hubs with thousands of people in New Delhi or San Francisco.
+       At Cobot we value diversity in all aspects of our team and are committed towards 
+       closing the gender gap in the tech industry which is why we are proud to support RGSoC.
+      years:
+        - 2017
+        - 2018
+    - name: Honeybadger
+      id: honeybadger
+      url: https://www.honeybadger.io
+      text: |-
+        <a href="https://www.honeybadger.io" target="_blank">Honeybadger</a> is the
+        best exception monitoring service on the planet — in fact, it’s so awesome,
+        you’ll want to get more errors in your application just so you can use it more!
+        Built on Rails, it helps developers deliver great experiences to their users.
+        We at Honeybadger love the open source community, and we are happy to sponsor
+        RGSoC to help make that community even better.
+      years:
+        - 2013
+        - 2014
+        - 2016
+        - 2017
+        - 2018
+    - name: Contentful 
+      id: contentful
+      url: https://www.contentful.com/
+      text: |-
+        <a href="https://www.contentful.com/">Contentful</a> provides content infrastructure for digital teams to 
+        power websites, apps, and devices. Unlike a CMS, Contentful was built to integrate with the modern software 
+        stack. It offers a central hub for structured content, powerful management and delivery APIs, and a customizable 
+        web app that enable developers and content creators to ship their products faster.  
+        One of our core value as a company is "Learn continuously" so it only makes sense to support those eager to do so. 
+        2018 is the first year we're backing RGSoC but it definitely won't be the last one. 
+      years:
+        - 2018
+    - name: Nextcloud 
+      id: nextcloud
+      url: https://nextcloud.com/
+      text: |-
+        <a href="https://nextcloud.com/">Nextcloud</a> is the next generation open source, self-hosted, enterprise-ready file access and communication platform. 
+        Sync your files, contacts, calendars and communicate & collaborate across your devices. 
+        Nextcloud puts you back in control and is built by an open community where you can contribute!
+      years:
+        - 2017
+        - 2018
+    - name: Sentry
+      id: sentry
+      url: https://getsentry.com
+      text: |-
+        <a href="https://getsentry.com">Sentry</a> is modern error logging. Get the
+        full stacktrace, request info, and user context of every error. Sentry is
+        completely open source (client and server), supports over two dozen languages
+        and frameworks, has hundreds of contributors, and is deployed in tens of
+        thousands of organizations. Sentry is excited to support Rails Girls Summer of
+        Code and help nurture the next generation of women engineers. We can't wait to
+        see what they can do!
+      years:
+        - 2016
+        - 2017
+        - 2018
+    - name: Softwire
+      id: softwire
+      url: https://www.softwire.com/
+      text: |-
+        <a href="https://www.softwire.com/" target="_blank">Softwire</a> is a bespoke
+        software design and development company with offices in London and Manchester.
+        Our brilliant staff have a passion for technology and Open Source (we're keen
+        contributors to 24 Pull Requests) and we're excited to help Rails Girls Summer of Code
+        support women following those same passions.
+      years:
+        - 2016
+        - 2017
+        - 2018
+    - name: openSUSE
+      id: opensuse
+      url: https://www.opensuse.org/
+      text: |-
+        The <a href="https://www.opensuse.org/">openSUSE</a> project is a worldwide
+        effort that promotes the use and development of Linux. openSUSE cares about the
+        Free and Open Source Software community and supports Rails Girls Summer of Code
+        because the FOSS community is a more vibrant community with female coders.
+      years:
+        - 2016
+        - 2017
+        - 2018
+    - name: Synack
+      id: synack
+      url: https://www.synack.com/
+      text: |-
+        <a href="https://www.synack.com/">Synack</a> is a security startup that has
+        created a unique Crowd Security Intelligence™ platform that delivers the most
+        secure, continuous, scalable, security assessment on the market.  Our team is
+        proud to support Rails Girls Summer of Code and celebrate their efforts
+        promoting diversity and equality in technology.
+      years:
+        - 2015
+        - 2016
+        - 2018
+    - name: Heroku
+      id: heroku
+      url: https://heroku.com
+      text: |-
+       <a href="https://heroku.com">Heroku</a>, a Salesforce company and industry pioneer in platform
+        as a service (PaaS), enables developers to build and run applications entirely in the cloud, 
+        without the need to purchase or maintain any servers or software. 
+        With Heroku you can focus on your app, not your infrastructure. 
+        As a long time supporter of the Ruby on Rails community, Heroku is a proud sponsor of Rails Girls Summer of Code, 
+        as we believe in empowering students and giving them the tools and resources they need to be successful in their respective communities.
+      years:
+        - 2017
+        - 2018
+    - name: Buffer
+      id: buffer
+      url: https://bufferapp.com
+      text: |-
+        <a href="https://bufferapp.com">Buffer</a> builds tools to help individuals, businesses and publishers
+        build an audience online and engage with followers as effectively as possible. In all things, we aspire 
+        to build equality and unity with our product, within our company, and in the world. Buffer is excited 
+        to support Rails Girls Summer of Code and its mission to bring more underrepresented people into open source! 
+        We believe tech is for everyone, and we build a stronger future when all are welcome.
+      years:
+        - 2015
+        - 2016
+        - 2018


### PR DESCRIPTION
create 2018 data files for conferences and sponsors so they can be referenced in other pages. For now I'm also leaving the data in the “current” overview until we figure out what will happen in 2019. 