### PR TITLE
Moved styles from styles to layout

### DIFF
--- a/assets/stylesheets/layout.scss
+++ b/assets/stylesheets/layout.scss
@@ -420,4 +420,8 @@ a.button-burger {
   height: 100%;
 }
 
+.conferences-container img {
+  width: 200px;
+  height: 200px;
+}
 

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -31,10 +31,6 @@
   {% endfor %}
 {% endfor %}
 
-.conferences-container img {
-  width: 200px;
-  height: 200px;
-}
 
 {% for conference in site.data.conferences %}
   .sponsors .{{ conference.id }} {


### PR DESCRIPTION
CSS refactoring. Issue #574 

Moved the small css snippet that styles images on the conferences page (`.conferences-container img`) from the `style.scss` file into the `layout.scss`