### PR TITLE
add 2019 announcement

### DIFF
--- a/blog/_posts/2019-03-20-the-future-of-rgsoc.md
+++ b/blog/_posts/2019-03-20-the-future-of-rgsoc.md
@@ -1,0 +1,43 @@
+---
+title: The future of RGSoC
+layout: post
+created_at: Wed Mar 20 2019
+permalink: blog/2019-03-20-the-future-of-rgsoc
+current: blog
+author: RGSoC Team
+twitter: RailsGirlsSoC
+categories:
+ - news
+---
+
+Dear friends! As some of you may have noticed, this year's RGSoC will be a bit different for all of us. Here is how and why.
+
+It took us a long time to get to where we are today. We’ve successfully organized RGSoC 6 times and over the last years we noticed more and more that the name Rails Girls Summer of Code does not fit our program anymore: We are not focused on “Rails”, but are language agnostic; we are no “girls” anymore and never have been, and although we still fiercely love the Rails Girls community we grew out of, our program has become so different that we want to find a more suitable name for it. A name that tells the world exactly what we stand for, tells sponsors what they can support and applicants what they can expect. 
+
+## Time time time 
+
+To do this, we need some time. We need to not only think about what name our program should have but also take some time to review all the feedback we’ve collected and implemented over the years, and take time to make our organizational structure better to prevent burnout of organizers, rewrite our guidelines, and make our support better for everyone. 
+
+Did you know that RGSoC has always been organized by a very small team? That team handles everything — the application phase for open source projects, communicating with the mentors, supporting the teams’ applications, the selection phase (hello 48-hour shifts of going through all applications in a short amount of time), developing and maintaining the app for all this, reaching out to sponsors and handling finances, finding and onboarding supervisors of the teams, organizing all the weekly calls and catch ups, updating our website, writing blog posts, reviewing pull requests, sending out newsletters, finding a trust committee, all the way through how to offer fair stipends to teams in every corner of the world and collecting swag from sponsors to then lovingly pack them into (not so) little care packages for each and every applicant. What a list! (And not even close to complete)
+
+## Make it simple 
+
+We want to make it easier for us to run the scholarship program and easier for everyone else to understand what we do and to get on board. During last year’s edition, we started planning our rebranding phase, what we would need from it, what we wish for the future and how much time we’d need for it. We started defining our target audience, rethinking our content and brainstorming on a name. But we realized quickly there was no way we could do both — run the program this year and also rework, rebrand and redesign it on the fly.   
+
+After jumping into this wild adventure 6 years ago and running ever since, we will take a breather, drink some water, get out our thinking caps and paper and pens and will fix the things that needs fixing and keep the things that work. In the end, we hope to present you with the  program you know and love, but better organized. A program that still wants to fund underrepresented people working on Open Source projects. But one that we had time to create. And one with a new name. 
+
+## Where you come in 
+
+Do you want to help us? RGSoC was always a community-focused program and as such, we’d love to get your feedback of what worked and what didn’t over the years, what you’d like to keep and how you’d want to see us grow. We’ve put together a feedback form to collect your input below.  
+
+[Give us your thoughts](https://rgsoc.typeform.com/to/cUikUg)
+
+But that’s not all. We still want to make sure we connect great and beginner-friendly open source projects with people who want to work on them; our goal is to publish a list of approved open source projects in May that aspiring open source contributors can work on. You can submit your project [here](https://teams.railsgirlssummerofcode.org/projects). We also plan to publish a guide for companies on how to host teams this year. So if you are one of these companies wanting to get involved — [let us know!](mailto:contact@rgsoc.org) We’ll do our best to connect you with people who want to work on open source projects. 
+
+We are looking for sponsors who want to fund our rebranding work and keep our organizing team going this year, so that we can soon announce that we will be back in 2020 with a brand new name and ready to change lives again! If you’re interested in supporting us this year, please drop us a line: [campaign@rgsoc.org](mailto:campaign@rgsoc.org)
+
+Thank you everyone for making the dream RGSoC a reality until now! Thank you for being part of a wonderful journey. We are so excited to work together with you on a new chapter of our dreams. 
+
+
+<iframe src="https://player.vimeo.com/video/265904630" width="640" height="360" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+<p><a href="https://vimeo.com/265904630">You Are Accepted To RGSoC 2018!</a> from <a href="https://vimeo.com/user51331690">Rails Girls Summer of Code</a> on <a href="https://vimeo.com">Vimeo</a>.</p>

--- a/blog/_posts/2019-03-21-the-future-of-rgsoc.md
+++ b/blog/_posts/2019-03-21-the-future-of-rgsoc.md
@@ -1,8 +1,8 @@
 ---
 title: The future of RGSoC
 layout: post
-created_at: Wed Mar 20 2019
-permalink: blog/2019-03-20-the-future-of-rgsoc
+created_at: Thu Mar 21 2019
+permalink: blog/2019-03-21-the-future-of-rgsoc
 current: blog
 author: RGSoC Team
 twitter: RailsGirlsSoC
@@ -32,7 +32,7 @@ Do you want to help us? RGSoC was always a community-focused program and as such
 
 [Give us your thoughts](https://rgsoc.typeform.com/to/cUikUg)
 
-But that’s not all. We still want to make sure we connect great and beginner-friendly open source projects with people who want to work on them; our goal is to publish a list of approved open source projects in May that aspiring open source contributors can work on. You can submit your project [here](https://teams.railsgirlssummerofcode.org/projects). We also plan to publish a guide for companies on how to host teams this year. So if you are one of these companies wanting to get involved — [let us know!](mailto:contact@rgsoc.org) We’ll do our best to connect you with people who want to work on open source projects. 
+But that’s not all. We still want to make sure we connect great and beginner-friendly open source projects with people who want to work on them; our goal is to publish a list of approved open source projects in April that aspiring open source contributors can work on. You can submit your project [here](https://teams.railsgirlssummerofcode.org/projects). We also plan to publish a guide for companies on how to host teams this year. So if you are one of these companies wanting to get involved — [let us know!](mailto:contact@rgsoc.org) We’ll do our best to connect you with people who want to work on open source projects. 
 
 We are looking for sponsors who want to fund our rebranding work and keep our organizing team going this year, so that we can soon announce that we will be back in 2020 with a brand new name and ready to change lives again! If you’re interested in supporting us this year, please drop us a line: [campaign@rgsoc.org](mailto:campaign@rgsoc.org)
 


### PR DESCRIPTION
Brief comments: 
- It says project list will be published in May; the timeline suggests April (see https://github.com/rails-girls-summer-of-code/summer-of-code/pull/590) so we need to decide on a preferred date
- the blog post has today's date; if we change that, we need to change links on the site (e.g. call to action) accordingly (see https://github.com/rails-girls-summer-of-code/summer-of-code/pull/590)