### PR TITLE
add redirect gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ gem 'jekyll'
 gem 'github-pages'
 gem 'geocoder'
 gem 'lolize', :require => 'lolize/auto'
+gem 'jekyll-redirect-from'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,7 @@ DEPENDENCIES
   geocoder
   github-pages
   jekyll
+  jekyll-redirect-from
   lolize
 
 RUBY VERSION

--- a/blog/_posts/2019-05-08-code-with-these-oss-projects.md
+++ b/blog/_posts/2019-05-08-code-with-these-oss-projects.md
@@ -3,6 +3,7 @@ title: Code with these open source projects this season
 layout: post
 created_at: Wed May 08 2019
 permalink: blog/2019-05-08-code-with-these-oss-projects
+redirect_from: "/code-with-these-oss-projects/"
 current: blog
 author: RGSoC Team
 twitter: RailsGirlsSoC

--- a/blog/_posts/2019-05-08-code-with-these-oss-projects.md
+++ b/blog/_posts/2019-05-08-code-with-these-oss-projects.md
@@ -2,7 +2,7 @@
 title: Code with these open source projects this season
 layout: post
 created_at: Wed May 08 2019
-perma**Link**: blog/2019-05-08-code-with-these-oss-projects
+permalink: blog/2019-05-08-code-with-these-oss-projects
 current: blog
 author: RGSoC Team
 twitter: RailsGirlsSoC


### PR DESCRIPTION
Our latest blog post had a a little syntax error in the frontmatter, which means the first version of the post we shared had a faulty permalink (`blog-post-link` rather than `/blog/blog-post-link`). 

Since this has happened in the past, I've installed the redirect gem, which allows us to set up redirects in case the urls/permalinks of posts / pages change. this can come in quite handy!

Would love for someone else to take a look at this PR though and suggest possible improvements. 