### PR TITLE
Create Student page for 2020

### DIFF
--- a/students.html
+++ b/students.html
@@ -1,0 +1,36 @@
+---
+layout: page
+title: Students
+class: page page-students
+current: students
+current-sub: students
+permalink: students/
+sidebar: content
+---
+
+<h1>{{page.title}}</h1>
+
+<p>Here’s a helpful starting point for all the things you need to know as a student of RGSoC.</p>
+
+<h4>Important Dates</h4>
+<p>Student applications for this year's Rails Girls Summer of Code will happen in February 2020.</p>
+
+<h4><a href="/students/application">Application Guide</a></h4>
+<p>All the information you need to make a complete application, including how to apply using the <a href="https://teams.railsgirlssummerofcode.org/teams" target="_blank">Teams App</a>, and how to organize yourselves should you be granted a scholarship.</p>
+
+<h4><a href="/students/finding-your-team/" target="_blank">Finding Your Team</a></h4>
+<p>Tips for finding a teammate and Coaches, as well as helpful guidelines on public and social media posts.</p>
+
+<h4><a href="/students/todo" target="_blank">What to expect</a></h4>
+<p>Activities during the program and suggestions on how to meet the requirements for participating in RGSoC. This section also gives you an idea of what a season on coding will look like.</p>
+
+<h4><a href="/students/log" target="_blank">Daily Team Log</a></h4>
+<p>Immerse yourself in Open Source culture by recording the main day-to-day achievements and problems in a brief online blog. Read our tips for your log.</p>
+
+<h4>A note on Conferences</h4>
+<p>In the past we collaborated with conferences all over the world, offering students a chance to attend for free. While recognizing the excellent opportunity for networking and development this offers, we’ve decided not to run this part of the program in 2020.</p>
+
+<p>However, you may be able to source tickets to conferences via our friends at <a href="https://diversitytickets.org/en" target="_blank">Diversity Tickets</a>.</p>
+
+<div style="width:650px; height:400px" id="map"></div>
+


### PR DESCRIPTION
Created using the 2017 page as a reference. The Student page was not part of the 2018 website/program.