### PR TITLE
Update navigation bar for 2020 season

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -15,16 +15,19 @@
       <li><a href="/guide/coaching">Coaches</a></li>
       <li><a href="/guide/coaching-company">Coaching Company</a></li>
       <li><a href="/guide/projects">Project Mentor</a></li>
+      <li><a href="/guide/supervisors">Supervisor</a></li>
     </ul>
     <ul class="col-sm-3">
       <li>Students</li>
+      <li><a href="/students/application">Info for Students</a></li>
       <li><a href="/students/application">Application Guide</a></li>
       <li><a href="/students/finding-your-team">Finding your team</a></li>
+      <li><a href="/students/todo">What to expect</a></li>
     </ul>
 
     <ul class="col-sm-3">
       <li>Sponsors</li>
-      <li><a href="/sponsors">2018 Sponsors &hearts;</a></li>
+      <li><a href="/sponsors">2020 Sponsors &hearts;</a></li>
       <!--<li><a href="/sponsors/coaching-companies">2017 Coaching Companies</a></li>-->
       <li><a href="/sponsors/packages">Sponsorship Packages</a></li>
       <li><a href="/sponsorship-guidelines">Sponsorship Guidelines</a></li>


### PR DESCRIPTION
Inc. reinstating pages not included in 2018 such as supervisors. Conferences excluded for 2020.