### PR TITLE
Change package names for Stripe

### DIFF
--- a/_includes/sponsor_packages.html
+++ b/_includes/sponsor_packages.html
@@ -1,15 +1,15 @@
 <ul id="sponsor-packages">
   <li>
     <h4>Trailblazer: 5000 USD</h4>
-    <a href="#" class="donate-button button" data-amount="5000" data-name="Gold">Become a Sponsor</a>
+    <a href="#" class="donate-button button" data-amount="5000" data-name="Trailblazer">Become a Sponsor</a>
   </li>
   <li>
     <h4>Pioneer: 2500 USD</h4>
-    <a href="#" class="donate-button button" data-amount="2500" data-name="Silver">Become a Sponsor</a>
+    <a href="#" class="donate-button button" data-amount="2500" data-name="Pioneer">Become a Sponsor</a>
   </li>
   <li>
     <h4>Innovator: 1000 USD</h4>
-    <a href="#" class="donate-button button" data-amount="1000" data-name="Bronze">Become a Sponsor</a>
+    <a href="#" class="donate-button button" data-amount="1000" data-name="Innovator">Become a Sponsor</a>
   </li>
 </ul>
 

--- a/_includes/sponsor_packages.html
+++ b/_includes/sponsor_packages.html
@@ -1,14 +1,17 @@
 <ul id="sponsor-packages">
   <li>
-    <h4>Trailblazer: 5000 USD</h4>
+    <h4 align="center">Trailblazer:</h4>
+    <h4 align="center">5000 USD</h4>
     <a href="#" class="donate-button button" data-amount="5000" data-name="Trailblazer">Become a Sponsor</a>
   </li>
   <li>
-    <h4>Pioneer: 2500 USD</h4>
+    <h4 align="center">Pioneer:</h4>
+    <h4 align="center">2500 USD</h4>
     <a href="#" class="donate-button button" data-amount="2500" data-name="Pioneer">Become a Sponsor</a>
   </li>
   <li>
-    <h4>Innovator: 1000 USD</h4>
+    <h4 align="center">Innovator:</h4>
+    <h4 align="center">1000 USD</h4>
     <a href="#" class="donate-button button" data-amount="1000" data-name="Innovator">Become a Sponsor</a>
   </li>
 </ul>


### PR DESCRIPTION
Update the sponsor package names from gold, silver, bronze for 2020 campaign.