### PR TITLE
Remove conference section of footer for 2020

### DIFF
--- a/_includes/sponsors_footer.html
+++ b/_includes/sponsors_footer.html
@@ -1,4 +1,4 @@
-<h3>2018 Sponsors</h3>
+<h3>2020 Sponsors</h3>
 <ul>
 {% for package in site.data.packages %}
   <li class="sponsors {{ package.name | downcase }}">
@@ -20,7 +20,11 @@
   </li>
 {% endfor %}
 <p>Note: the stars on the logos represent the number of RGSoC editions supported by the sponsor</p>
-{% if site.data.conferences %}
-  {% include conferences_footer.html %}
-{% endif %}
+  
+  <!-- <section>
+    {% if site.data.conferences %}
+    {% include conferences_footer.html %}
+    {% endif %}
+  </section> -->
+
 </ul>


### PR DESCRIPTION
Not offering conferences for 2020. Section changed to a note so not visible on the homepage and sponsors page for 2020.