### PR TITLE
Move Innovator sponsors

### DIFF
--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -22,18 +22,10 @@
       - 2018
       - 2020
 
-#- name: Trailblazer
-#  title: Trailblazer Sponsors
-#  sponsors:
-
-#- name: Pioneer
-#  title: Pioneer Sponsors
-#  sponsors:
-
 - name: Innovator
   title: Innovator Sponsors
   sponsors:
-  - name: Honeybadger
+    - name: Honeybadger
       id: honeybadger
       url: https://www.honeybadger.io
       text: |-
@@ -50,3 +42,11 @@
         - 2017
         - 2018
         - 2020
+
+#- name: Trailblazer
+#  title: Trailblazer Sponsors
+#  sponsors:
+
+#- name: Pioneer
+#  title: Pioneer Sponsors
+#  sponsors:


### PR DESCRIPTION
Move above Trailblazer and Pioneers, which are currently not visible