### PR TITLE
Revert package names to Bronze, Silver, Gold

### DIFF
--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -22,15 +22,15 @@
       - 2018
       - 2020
 
-#- name: Trailblazer
+#- name: Gold
 #  title: Trailblazer Sponsors
 #  sponsors: 
 
-#- name: Pioneer
+#- name: Silver
 #  title: Pioneer Sponsors
 #  sponsors: 
 
-- name: Innovator
+- name: Bronze
   title: Innovator Sponsors
   sponsors: 
   - name: Honeybadger


### PR DESCRIPTION
YAML invalid, so changing names to previous packages (but new titles show on page)