### PR TITLE
Revert "Add Malwarebytes as Pioneer sponsor"

### DIFF
--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -98,22 +98,6 @@
     years:
       - 2020
 
-  - name: Malwarebytes
-    id: malwarebytes
-    url: http://www.malwarebytes.org
-    text: |-
-      <a href="http://www.malwarebytes.org" target="_blank">Malwarebytes</a> proactively
-      protects people and businesses against dangerous threats such as malware, ransomware
-      and exploits that escape detection by traditional solutions, giving users the freedom
-      to live malware-free. Malwarebytes is deeply invested in the developer community and
-      believe brilliant code can change the world. That's why we're proud to support the Rails
-      Girls Summer of Code, its participants, and its mission.
-    years:
-      - 2014
-      - 2016
-      - 2017
-      - 2020
-
 - name: Innovator
   title: Innovator Sponsors
   sponsors:


### PR DESCRIPTION
Reverts rails-girls-summer-of-code/summer-of-code#842

To see if this 'undoes' issue with archived campaigns no longer showing