### PR TITLE
Unhide link to logos in Dropbox

### DIFF
--- a/about/press.html
+++ b/about/press.html
@@ -156,7 +156,9 @@ permalink: /about/press/
       <br>
       <h3 id="logos">Logos</h3>
 
-      <p>Here are some versions of our logo.
+      <p>Various versions of the RGSoC logo can be found in <a href="https://www.dropbox.com/sh/jrg8tcbo0z8bf63/AACMw8iKblmX5HhHhrcy1rbna?dl=0" target="_blank">this Dropbox folder</a>, together with the vectorial versions.</p>
+
+      <!-- <p>Here are some versions of our logo.
             <!--, they can also be found in <a href="https://www.dropbox.com/sh/ng9p8d5hba425ht/AAB18_F_NZzX_UlQL8LB1caMa?dl=0" target="_blank">this folder</a>, together with the vectorial version of all the logos.</p>
 
       <ul class="photo-gallery">


### PR DESCRIPTION
Photos of previous student teams moved to unshared folder so okay for Dropbox to be accessed publically