### PR TITLE
Remove warning confusion

### DIFF
--- a/about/code-of-conduct.html
+++ b/about/code-of-conduct.html
@@ -46,7 +46,7 @@ permalink: /about/code-of-conduct/
 	<li>Attempt collaboration before conflict</li>
 	<li>Refrain from demeaning, discriminatory, or harassing behavior and speech</li>
 	<li>Be mindful of your surroundings and of your fellow participants</li>
-	<li>Alert the trust committee if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they may seem inconsequential</li>
+	<li>Alert the Trust Committee if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they may seem inconsequential</li>
 	<li>Community event venues may be shared with members of the public; please be respectful to all patrons of these locations</li>
 </ul>
 
@@ -75,12 +75,12 @@ permalink: /about/code-of-conduct/
 
 <p>Anyone asked to stop unacceptable behavior is expected to comply immediately. If a community member engages in unacceptable behavior, the community organizers may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community.</p>
 
-<p>When unacceptable behavior is reported, the Rails Girls Summer of Code team will take action and send out a first and last warning to the person who conducted the unacceptable behavior. If any further breaches of our Code of Conduct are reported, the person will be removed from the program immediately, without any further warning necessary.</p>
+<p>When unacceptable behavior is reported, the Rails Girls Summer of Code team will take action and send a written warning to the person who conducted the unacceptable behavior. If any further breaches of our Code of Conduct are reported, the person will be removed from the program immediately, without any further warning necessary.</p>
 
 <h3 id="witness">If You Witness or Are Subject to Unacceptable Behavior</h3>
-<p>If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a member of the trust committee as soon as possible.</p>
+<p>If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a member of the RGSoC organiser team or Trust Committee as soon as possible.</p>
 
-<p>Additionally, members of the trust committee are available to help community members engage with local law enforcement or to otherwise help those experiencing unacceptable behavior to feel safe. In the context of in-person events, organizers will also provide escorts as desired by the person experiencing distress.</p>
+<p>Additionally, members of the Trust Committee are available to help community members engage with local law enforcement or to otherwise help those experiencing unacceptable behavior to feel safe. In the context of in-person events, organizers will also provide escorts as desired by the person experiencing distress.</p>
 
 <h2 id="scope">Scope</h2>
 <p>We expect all community participants (contributors, paid or otherwise; sponsors; and other guests) to abide by this Code of Conduct in all community venues — online and in-person — as well as in all one-to-one communications during all activities related to Rails Girls Summer of Code.</p>


### PR DESCRIPTION
Changed "send a first and last warning" to read as a single warning (as intended) to remove confusion