### PR TITLE
Link to blog post cancelling RGSoC

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,8 @@ permalink: /
     <h3>Jul – Sept <span class="fa fa-star"></span> Worldwide</h3>
     <!--<p class="cta"><a href="/guide/projects/">SUBMIT YOUR OPEN SOURCE PROJECT</a></p>-->
     <!--<p class="cta"><a href="https://teams.railsgirlssummerofcode.org/apply">SUBMIT YOUR STUDENT APPLICATION</a></p>-->
-    <p class="cta"><a href="https://railsgirlssummerofcode.org/about/">FIND OUT MORE</a></p>
+    <!--<p class="cta"><a href="https://railsgirlssummerofcode.org/about/">FIND OUT MORE</a></p>-->
+    <p class="cta"><a href="https://railsgirlssummerofcode.org/blog/2020-06-15-foundation-update">Travis Foundation is closing. Find out more</a></p>
   </div>
 </header>
 <div class="bg--grey">


### PR DESCRIPTION
Update header to direct visitors to info about Travis Foundation closure