### PR TITLE
Hide sponsorship nav menu

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -26,14 +26,14 @@
       <li><a href="/students/todo">What to expect</a></li>
       <li><a href="/students/faq">Applicant FAQs</a></li>
     </ul>
-
+<!--
     <ul class="col-sm-3">
       <li>Sponsors</li>
       <li><a href="/sponsors">2020 Sponsors &hearts;</a></li>
-      <!--<li><a href="/sponsors/coaching-companies">2017 Coaching Companies</a></li>-->
       <li><a href="/sponsors/packages">Sponsorship Packages</a></li>
       <li><a href="/sponsorship-guidelines">Sponsorship Guidelines</a></li>
-    </ul>
+    </ul>-->
+      <!--<li><a href="/sponsors/coaching-companies">2017 Coaching Companies</a></li>-->
   </nav>
 </div>
 <div class="container">


### PR DESCRIPTION
Precaution to remove sponsor info while TF entity is being shutdown. Menus hidden are:
- 2020 Sponsors ♥
- Sponsorship Packages
- Sponsorship Guidelines