### PR TITLE
Fix footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,11 +1,11 @@
   <footer class="footer" id="footer">
-<!--
     <div class="row footer-child">
       <div class="container sponsor-container" id="sponsors">
+        {% comment %}
         {% if page.sponsors %}
-          {% include sponsors_footer.html %}
+        {% include sponsors_footer.html %}
         {% endif %}
--->
+        {% endcomment %}
       </div>
     </div>
     <div class="row footer-child">


### PR DESCRIPTION
Fixes #969 

Instead of HTML comment tag, Jekyll comments have been used which removes the tag in the footer.

Please see the attached screenshot.

![Screenshot from 2021-03-09 12-01-54](https://user-images.githubusercontent.com/42573842/110428466-4cccae00-80cf-11eb-92fb-f7db2b6e3b29.png)
