### PR TITLE
Remove arrow on the footer home page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,9 +5,9 @@
         {% if page.sponsors %}
           {% include sponsors_footer.html %}
         {% endif %}
--->
       </div>
     </div>
+-->
     <div class="row footer-child">
       <div class="container">
         <h3>Stay up to date</h3>
@@ -33,7 +33,6 @@
       </div>
     </div>
   </footer>
-</div>
 <script src="{{ site.baseurl }}/assets/javascripts/vendor/shariff.min.js"></script>
 <script type="text/javascript" src="{{ site.baseurl }}/assets/javascripts/main.js"></script>
 <script>


### PR DESCRIPTION
There was an extra div and the comment arrow was rendered on the home page

https://railsgirlssummerofcode.org/